### PR TITLE
Simplified API

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -23,9 +23,6 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python_version }}
-    - name: Run Docker services
-      run: |
-        ./ensure_eosio.sh
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -38,11 +35,15 @@ jobs:
       run: |
         poetry run mypy aioeos
     - name: Test with pytest
+      env:
+        # eosio node won't bootstrap on Github Actions
+        DISABLE_RPC_TESTS: 1
       run: |
         poetry run pytest --cov --cov-report xml
     - name: Uploading coverage
       uses: codecov/codecov-action@v1
       with:
+        token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
         file: ./coverage.xml # optional
         flags: unittests # optional
         name: codecov-umbrella # optional

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -23,6 +23,9 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python_version }}
+    - name: Run Docker services
+      run: |
+        ./ensure_eosio.sh
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -22,3 +22,11 @@ $ pip install aioeos
 ## Documentation
 
 Docs and usage examples are available [here](https://aioeos.readthedocs.io/en/latest).
+
+## Unit testing
+
+To run unit tests, you need to bootstrap an EOS testnet node first. Use the provided `ensure_eosio.sh` script.
+
+```
+$ ./ensure_eosio.sh
+```

--- a/aioeos/account.py
+++ b/aioeos/account.py
@@ -1,0 +1,63 @@
+from typing import Optional
+
+from aioeos.keys import EOSKey
+from aioeos.types import EosPermissionLevel, EosPermissionLevelWeight
+
+
+class EOSAccount:
+    """
+    Describes account on EOS blockchain. Contrary to other blockchains such as
+    Bitcoin or Ethereum, public key is not an address. An account can have
+    multiple keys with certain permissions, the default ones are "active" and
+    "owner". These keys are specified in the transaction which creates the
+    account in the first place.
+
+    Class provides a set of helper methods for generating objects such as
+    authorizations.
+
+    :param name: name of the account,
+
+    Please provide key in one of the formats - EOSKey instance, private key in
+    WIF format and public key. Only one of these is accepted. If no key is
+    provided, a new one will be generated.
+
+    ;param key: EOSKey instance,
+    :param private_key: private key in wif format,
+    :param public_key: public key
+    """
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        key: Optional[EOSKey] = None,
+        private_key: str = '',
+        public_key: str = '',
+    ):
+        assert name, "Account name can't be empty"
+
+        # While this could be written as some kind of binary operation and it
+        # would be clever and cool, this is more clear
+        assert any((
+            key and not private_key and not public_key,
+            not key and private_key and not public_key,
+            not key and not private_key and public_key,
+            not key and not private_key and not public_key
+        )), 'Exactly 1 key is required'
+
+        self.name = name
+        self.key = (
+            key or EOSKey(public_key=public_key, private_key=private_key)
+        )
+
+    def authorization(self, permission: str) -> EosPermissionLevel:
+        """Creates authorization object with given permission"""
+        return EosPermissionLevel(actor=self.name, permission=permission)
+
+    def permission_level_weight(
+        self, permission: str, weight: int
+    ) -> EosPermissionLevelWeight:
+        return EosPermissionLevelWeight(
+            permission=self.authorization(permission),
+            weight=weight
+        )

--- a/aioeos/contracts/eosio.py
+++ b/aioeos/contracts/eosio.py
@@ -1,21 +1,38 @@
 """Helpers for creating actions on eosio contract"""
-from aioeos.types import EosAction
+from dataclasses import dataclass
+from typing import Optional
+
+from aioeos.types import (
+    BaseAbiObject, Name, EosAction, EosAuthority
+)
+
+
+@dataclass
+class NewAccountPayload(BaseAbiObject):
+    creator: Name
+    name: Name
+    owner: EosAuthority
+    active: EosAuthority
 
 
 def newaccount(
-    creator, account_name, owner_keys, active_keys=None, authorization=[]
+    creator,
+    account_name,
+    *,
+    owner: EosAuthority,
+    active: Optional[EosAuthority] = None,
+    authorization=[]
 ) -> EosAction:
-    active_keys = owner_keys if not active_keys else active_keys
     return EosAction(
         account='eosio',
         name='newaccount',
         authorization=authorization,
-        data={
-            'creator': creator,
-            'name': account_name,
-            'owner': owner_keys,
-            'active': active_keys
-        }
+        data=NewAccountPayload(
+            creator=creator,
+            name=account_name,
+            owner=owner,
+            active=active if active else owner
+        )
     )
 
 

--- a/aioeos/contracts/eosio.py
+++ b/aioeos/contracts/eosio.py
@@ -1,18 +1,7 @@
 """Helpers for creating actions on eosio contract"""
-from dataclasses import dataclass
 from typing import Optional
 
-from aioeos.types import (
-    BaseAbiObject, Name, EosAction, EosAuthority
-)
-
-
-@dataclass
-class NewAccountPayload(BaseAbiObject):
-    creator: Name
-    name: Name
-    owner: EosAuthority
-    active: EosAuthority
+from aioeos.types import EosAction, EosAuthority
 
 
 def newaccount(
@@ -27,12 +16,12 @@ def newaccount(
         account='eosio',
         name='newaccount',
         authorization=authorization,
-        data=NewAccountPayload(
-            creator=creator,
-            name=account_name,
-            owner=owner,
-            active=active if active else owner
-        )
+        data={
+            'creator': creator,
+            'name': account_name,
+            'owner': owner,
+            'active': active if active else owner
+        }
     )
 
 

--- a/aioeos/keys.py
+++ b/aioeos/keys.py
@@ -1,8 +1,11 @@
-import base58
-import ecdsa
 import re
 import hashlib
 import secrets
+
+import base58
+import ecdsa
+
+from aioeos.types import EosKeyWeight
 
 
 class EOSKey:
@@ -211,7 +214,7 @@ class EOSKey:
         i = self._recovery_pubkey_param(digest, sig) + 4 + 27
         return f'SIG_K1_{self._check_encode(bytes([i]) + sig, "K1")}'
 
-    def verify(self, encoded_sig, digest):
+    def verify(self, encoded_sig, digest) -> bool:
         """Verifies signature with private key"""
         _, key_type, signature = encoded_sig.split('_')
         try:
@@ -222,3 +225,10 @@ class EOSKey:
         except (ecdsa.keys.BadSignatureError, TypeError):
             return False
         return True
+
+    def to_key_weight(self, weight: int) -> EosKeyWeight:
+        return EosKeyWeight(key=self.to_public(), weight=weight)
+
+    def __eq__(self, other) -> bool:
+        assert isinstance(other, EOSKey), 'Can compare only to EOSKey instance'
+        return self.to_public() == other.to_public()

--- a/aioeos/rpc.py
+++ b/aioeos/rpc.py
@@ -22,7 +22,7 @@ ERROR_NAME_MAP = {
 }
 
 
-def mixed_to_dict(payload: Union[Dict, BaseAbiObject]) -> Dict:
+def mixed_to_dict(payload: Union[Dict, BaseAbiObject]):
     """
     Recursively converts payload with mixed BaseAbiObjects and dicts to dict
     """

--- a/aioeos/serializer.py
+++ b/aioeos/serializer.py
@@ -210,6 +210,20 @@ class AbiObjectSerializer(BaseSerializer):
         return cursor, self.abi_class(**values)
 
 
+class AbiActionPayloadSerializer(BaseSerializer):
+    def serialize(self, value: types.AbiActionPayload) -> bytes:
+        assert not isinstance(value, dict), 'Convert data to ABI format first'
+
+        if isinstance(value, bytes):
+            return AbiBytesSerializer().serialize(value)
+
+        return AbiObjectSerializer(type(value)).serialize(value)
+
+    def deserialize(self, value: bytes) -> Tuple[int, bytes]:
+        # TODO: figure out how to convert it back to BaseAbiObject or dict
+        return AbiBytesSerializer().deserialize(value)
+
+
 TYPE_MAPPING = {
     types.UInt8: BasicTypeSerializer('B'),
     types.UInt16: BasicTypeSerializer('H'),
@@ -224,7 +238,7 @@ TYPE_MAPPING = {
     types.Name: AbiNameSerializer(),
     types.VarUInt: VarUIntSerializer(),
     types.AbiBytes: AbiBytesSerializer(),
-    types.AbiActionPayload: AbiBytesSerializer(),  # type: ignore
+    types.AbiActionPayload: AbiActionPayloadSerializer(),  # type: ignore
     types.TimePoint: AbiTimePointSerializer(),
     types.TimePointSec: AbiTimePointSecSerializer(),
     str: AbiStringSerializer()

--- a/aioeos/serializer.py
+++ b/aioeos/serializer.py
@@ -213,11 +213,12 @@ class AbiObjectSerializer(BaseSerializer):
 class AbiActionPayloadSerializer(BaseSerializer):
     def serialize(self, value: types.AbiActionPayload) -> bytes:
         assert not isinstance(value, dict), 'Convert data to ABI format first'
-
-        if isinstance(value, bytes):
-            return AbiBytesSerializer().serialize(value)
-
-        return AbiObjectSerializer(type(value)).serialize(value)
+        if types.is_abi_object(type(value)):
+            # mypy won't recognize that as a type check apparently
+            serializer = AbiObjectSerializer(type(value))
+            value = serializer.serialize(value)  # type: ignore
+        assert isinstance(value, bytes)
+        return AbiBytesSerializer().serialize(value)
 
     def deserialize(self, value: bytes) -> Tuple[int, bytes]:
         # TODO: figure out how to convert it back to BaseAbiObject or dict
@@ -283,12 +284,11 @@ class AbiListSerializer(BaseSerializer):
 
 
 def get_abi_type_serializer(abi_type: Type) -> BaseSerializer:
-    is_class = inspect.isclass(abi_type)
     if abi_type in TYPE_MAPPING:
         return TYPE_MAPPING[abi_type]
     elif getattr(abi_type, '_name', None) == 'List':
         return AbiListSerializer(abi_type)
-    elif is_class and issubclass(abi_type, types.BaseAbiObject):
+    elif types.is_abi_object(abi_type):
         return AbiObjectSerializer(abi_type)
 
     # if type is not supported, raise an Exception

--- a/aioeos/types/__init__.py
+++ b/aioeos/types/__init__.py
@@ -1,0 +1,28 @@
+from .abi import (
+    UInt8, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64, VarUInt, Float32,
+    Float64, TimePointSec, TimePoint, Name, AbiBytes, BaseAbiObject
+)  # noqa
+
+from .authority import (
+    EosPermissionLevel, EosKeyWeight, EosPermissionLevelWeight, EosWaitWeight,
+    EosAuthority
+)  # noqa
+
+from .transaction import (
+    AbiActionPayload, EosAction, EosTransaction
+)  # noqa
+
+
+__all__ = [
+    # base ABI types
+    'UInt8', 'UInt16', 'UInt32', 'UInt64', 'Int8', 'Int16', 'Int32', 'Int64',
+    'VarUInt', 'Float32', 'Float64', 'TimePointSec', 'TimePoint', 'Name',
+    'AbiBytes', 'BaseAbiObject',
+
+    # authority
+    'EosPermissionLevel', 'EosKeyWeight', 'EosPermissionLevelWeight',
+    'EosWaitWeight', 'EosAuthority',
+
+    # transaction
+    'AbiActionPayload', 'EosAction', 'EosTransaction'
+]

--- a/aioeos/types/__init__.py
+++ b/aioeos/types/__init__.py
@@ -1,6 +1,7 @@
 from .abi import (
     UInt8, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64, VarUInt, Float32,
-    Float64, TimePointSec, TimePoint, Name, AbiBytes, BaseAbiObject
+    Float64, TimePointSec, TimePoint, Name, AbiBytes, BaseAbiObject,
+    is_abi_object
 )  # noqa
 
 from .authority import (
@@ -17,7 +18,7 @@ __all__ = [
     # base ABI types
     'UInt8', 'UInt16', 'UInt32', 'UInt64', 'Int8', 'Int16', 'Int32', 'Int64',
     'VarUInt', 'Float32', 'Float64', 'TimePointSec', 'TimePoint', 'Name',
-    'AbiBytes', 'BaseAbiObject',
+    'AbiBytes', 'BaseAbiObject', 'is_abi_object',
 
     # authority
     'EosPermissionLevel', 'EosKeyWeight', 'EosPermissionLevelWeight',

--- a/aioeos/types/abi.py
+++ b/aioeos/types/abi.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, fields
 from datetime import datetime
-from typing import ClassVar, Dict, NewType, TYPE_CHECKING
+import inspect
+from typing import Any, ClassVar, Dict, NewType, TYPE_CHECKING
 
 
 # EOS ABI types
@@ -52,3 +53,9 @@ class BaseAbiObject:
     @classmethod
     def _serializable_fields(cls):
         return (x.name for x in fields(cls))
+
+
+def is_abi_object(obj: Any) -> bool:
+    """Object is an ABI object if it's a subclass of BaseAbiObject"""
+    is_class = inspect.isclass(obj)
+    return is_class and issubclass(obj, BaseAbiObject)

--- a/aioeos/types/abi.py
+++ b/aioeos/types/abi.py
@@ -1,6 +1,6 @@
-from dataclasses import dataclass, field, fields
+from dataclasses import dataclass, fields
 from datetime import datetime
-from typing import Any, ClassVar, Dict, List, NewType, TYPE_CHECKING, Union
+from typing import ClassVar, Dict, NewType, TYPE_CHECKING
 
 
 # EOS ABI types
@@ -44,8 +44,6 @@ else:
     # this type is weird because it's like int, but it has no fixed size
     VarUInt = NewType('VarUInt', int)
 
-AbiActionPayload = Union[Dict[str, Any], AbiBytes]
-
 
 @dataclass
 class BaseAbiObject:
@@ -54,36 +52,3 @@ class BaseAbiObject:
     @classmethod
     def _serializable_fields(cls):
         return (x.name for x in fields(cls))
-
-
-@dataclass
-class EosAuthorization(BaseAbiObject):
-    actor: Name
-    permission: Name
-
-
-@dataclass
-class EosAction(BaseAbiObject):
-    account: Name
-    name: Name
-    authorization: List[EosAuthorization]
-    data: AbiActionPayload
-
-
-@dataclass
-class EosExtension(BaseAbiObject):
-    extension_type: UInt16
-    data: AbiBytes
-
-
-@dataclass
-class EosTransaction(BaseAbiObject):
-    expiration: TimePointSec = field(default_factory=datetime.now)
-    ref_block_num: UInt16 = UInt16(0)
-    ref_block_prefix: UInt32 = 0
-    max_net_usage_words: VarUInt = 0
-    max_cpu_usage_ms: UInt8 = 0
-    delay_sec: VarUInt = 0
-    context_free_actions: List[EosAction] = field(default_factory=list)
-    actions: List[EosAction] = field(default_factory=list)
-    transaction_extensions: List[EosExtension] = field(default_factory=list)

--- a/aioeos/types/authority.py
+++ b/aioeos/types/authority.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass, field
+from typing import List
+
+from .abi import BaseAbiObject, UInt16, UInt32, Name
+
+
+@dataclass
+class EosPermissionLevel(BaseAbiObject):
+    actor: Name
+    permission: Name
+
+
+@dataclass
+class EosKeyWeight(BaseAbiObject):
+    key: str
+    weight: UInt16
+
+
+@dataclass
+class EosPermissionLevelWeight(BaseAbiObject):
+    permission: EosPermissionLevel
+    weight: UInt16
+
+
+@dataclass
+class EosWaitWeight(BaseAbiObject):
+    wait_sec: UInt32
+    weight: UInt16
+
+
+@dataclass
+class EosAuthority(BaseAbiObject):
+    threshold: UInt32 = 1
+    keys: List[EosKeyWeight] = field(default_factory=list)
+    accounts: List[EosPermissionLevelWeight] = field(default_factory=list)
+    waits: List[EosWaitWeight] = field(default_factory=list)

--- a/aioeos/types/authority.py
+++ b/aioeos/types/authority.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from typing import List
 
-from .abi import BaseAbiObject, UInt16, UInt32, Name
+from .abi import AbiBytes, BaseAbiObject, UInt16, UInt32, Name
 
 
 @dataclass
@@ -12,7 +12,7 @@ class EosPermissionLevel(BaseAbiObject):
 
 @dataclass
 class EosKeyWeight(BaseAbiObject):
-    key: str
+    key: AbiBytes
     weight: UInt16
 
 

--- a/aioeos/types/transaction.py
+++ b/aioeos/types/transaction.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Union
 from .abi import (
     AbiBytes, BaseAbiObject, UInt8, UInt16, UInt32, VarUInt, Name, TimePointSec
 )
-from .authority import EOSAuthorization
+from .authority import EosPermissionLevel
 
 
 AbiActionPayload = Union[Dict[str, Any], AbiBytes, BaseAbiObject]
@@ -15,7 +15,7 @@ AbiActionPayload = Union[Dict[str, Any], AbiBytes, BaseAbiObject]
 class EosAction(BaseAbiObject):
     account: Name
     name: Name
-    authorization: List[EOSAuthorization]
+    authorization: List[EosPermissionLevel]
     data: AbiActionPayload
 
 

--- a/aioeos/types/transaction.py
+++ b/aioeos/types/transaction.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Union
+
+from .abi import (
+    AbiBytes, BaseAbiObject, UInt8, UInt16, UInt32, VarUInt, Name, TimePointSec
+)
+from .authority import EOSAuthorization
+
+
+AbiActionPayload = Union[Dict[str, Any], AbiBytes, BaseAbiObject]
+
+
+@dataclass
+class EosAction(BaseAbiObject):
+    account: Name
+    name: Name
+    authorization: List[EOSAuthorization]
+    data: AbiActionPayload
+
+
+@dataclass
+class EosExtension(BaseAbiObject):
+    extension_type: UInt16
+    data: AbiBytes
+
+
+def _default_expiration():
+    return datetime.now() + timedelta(seconds=120)
+
+
+@dataclass
+class EosTransaction(BaseAbiObject):
+    # TAPOS fields
+    expiration: TimePointSec = field(default_factory=_default_expiration)
+    ref_block_num: UInt16 = 0
+    ref_block_prefix: UInt32 = 0
+
+    max_net_usage_words: VarUInt = 0
+    max_cpu_usage_ms: UInt8 = 0
+    delay_sec: VarUInt = 0
+    context_free_actions: List[EosAction] = field(default_factory=list)
+    actions: List[EosAction] = field(default_factory=list)
+    transaction_extensions: List[EosExtension] = field(default_factory=list)

--- a/aioeos/types/transaction.py
+++ b/aioeos/types/transaction.py
@@ -25,14 +25,12 @@ class EosExtension(BaseAbiObject):
     data: AbiBytes
 
 
-def _default_expiration():
-    return datetime.now() + timedelta(seconds=120)
-
-
 @dataclass
 class EosTransaction(BaseAbiObject):
     # TAPOS fields
-    expiration: TimePointSec = field(default_factory=_default_expiration)
+    expiration: TimePointSec = field(
+        default_factory=lambda: datetime.now() + timedelta(seconds=120)
+    )
     ref_block_num: UInt16 = 0
     ref_block_prefix: UInt32 = 0
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+  eosio:
+    image: ulamlabs/eos-testnet
+    container_name: eosio
+    ports:
+      - 8888:8888

--- a/ensure_eosio.sh
+++ b/ensure_eosio.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+x=0
+while true;
+do
+    docker ps | grep -q eos-testnet > /dev/null
+    if [ $? -eq 0 ]; then
+        y=0
+        while [ $y -lt 10 ];
+        do	
+            docker exec eos-testnet cleos get table eosio eosio delband &> /dev/null
+            if [ $? -eq 0 ]; then
+                echo "EOS bootstrapped ($y retries, $x reboots)"
+                exit 0
+            fi
+            ((y+=1))
+            sleep 10
+        done
+        echo Retry limit exceeded, rebooting
+    fi
+    ((x+=1))
+    docker-compose stop eos-testnet &> /dev/null
+    docker-compose rm -f &> /dev/null
+    docker-compose up -d eos-testnet &> /dev/null
+    sleep 5
+done

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,59 @@
+import random
+
+import pytest
+
+from aioeos.account import EOSAccount
+from aioeos.contracts import eosio
+from aioeos.rpc import EosJsonRpc
+from aioeos.types import EosAuthority, EosTransaction
+
+
+@pytest.fixture
+def rpc():
+    return EosJsonRpc(url='http://127.0.0.1:8888')
+
+
+@pytest.fixture
+def main_account():
+    return EOSAccount(
+        name='eostest12345',
+        private_key='5JeaxignXEg3mGwvgmwxG6w6wHcRp9ooPw81KjrP2ah6TWSECDN'
+    )
+
+
+@pytest.fixture
+async def second_account(loop, main_account, rpc):
+    name = ''.join(
+        random.choice('12345abcdefghijklmnopqrstuvwxyz')
+        for i in range(12)
+    )
+    account = EOSAccount(name=name)
+    block = await rpc.get_head_block()
+
+    owner = EosAuthority(
+        threshold=1,
+        keys=[account.key.to_key_weight(1)]
+    )
+
+    await rpc.sign_and_push_transaction(
+        EosTransaction(
+            ref_block_num=block['block_num'] & 65535,
+            ref_block_prefix=block['ref_block_prefix'],
+            actions=[
+                eosio.newaccount(
+                    main_account.name,
+                    account.name,
+                    owner=owner,
+                    authorization=[main_account.authorization('active')]
+                ),
+                eosio.buyrambytes(
+                    main_account.name,
+                    account.name,
+                    2048,
+                    authorization=[main_account.authorization('active')]
+                )
+            ],
+        ),
+        keys=[main_account.key]
+    )
+    return account

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,0 +1,37 @@
+import pytest
+
+from aioeos.account import EOSAccount
+from aioeos.keys import EOSKey
+
+
+def test_new_account():
+    account_1 = EOSAccount(name='account1')
+    account_2 = EOSAccount(name='account2')
+    assert account_1.key != account_2.key
+
+
+def test_only_one_key():
+    key = EOSKey()
+
+    # this is fine
+    EOSAccount(name='account', key=key)
+
+    # this isn't
+    with pytest.raises(AssertionError):
+        EOSAccount(name='account', key=key, public_key=key.to_public())
+
+    # absolutely wrong
+    with pytest.raises(AssertionError):
+        EOSAccount(
+            name='account',
+            key=key,
+            public_key=key.to_public(),
+            private_key=key.to_wif()
+        )
+
+
+def test_account_authorization():
+    account = EOSAccount(name='account')
+    authorization = account.authorization('active')
+    assert authorization.actor == account.name
+    assert authorization.permission == 'active'

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -35,3 +35,11 @@ def test_account_authorization():
     authorization = account.authorization('active')
     assert authorization.actor == account.name
     assert authorization.permission == 'active'
+
+
+def test_account_permission_level_weight():
+    account = EOSAccount(name='account')
+    authorization = account.authorization('active')
+    permission_level_weight = account.permission_level_weight('active', 3)
+    assert permission_level_weight.permission == authorization
+    assert permission_level_weight.weight == 3

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -1,4 +1,4 @@
-from aioeos.types import EosAction
+from aioeos.types import EosAction, EosAuthority
 from aioeos.contracts import eosio, eosio_token
 
 
@@ -36,20 +36,24 @@ def test_eosio_token_close():
     )
 
 
-def test_eosio_newaccount():
+def test_eosio_newaccount(main_account):
+    authority = EosAuthority(
+        threshold=1,
+        keys=[main_account.key.to_key_weight(1)]
+    )
     assert (
         eosio.newaccount(
-            'eosio', 'eosio2', ['keys']
+            main_account.name, 'eosio2', owner=authority
         ) == EosAction(
             account='eosio',
             name='newaccount',
             authorization=[],
-            data={
-                'creator': 'eosio',
-                'name': 'eosio2',
-                'owner': ['keys'],
-                'active': ['keys']
-            }
+            data=eosio.NewAccountPayload(
+                creator=main_account.name,
+                name='eosio2',
+                owner=authority,
+                active=authority
+            )
         )
     )
 

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -48,12 +48,12 @@ def test_eosio_newaccount(main_account):
             account='eosio',
             name='newaccount',
             authorization=[],
-            data=eosio.NewAccountPayload(
-                creator=main_account.name,
-                name='eosio2',
-                owner=authority,
-                active=authority
-            )
+            data={
+                'creator': main_account.name,
+                'name': 'eosio2',
+                'owner': authority,
+                'active': authority
+            }
         )
     )
 

--- a/tests/test_real_rpc.py
+++ b/tests/test_real_rpc.py
@@ -10,7 +10,7 @@ from aioeos.types import EosTransaction
     os.environ.get('DISABLE_RPC_TESTS'),
     reason='RPC tests are disabled'
 )
-async def test_tx_flow(rpc, main_account, second_account):
+async def test_sign_and_push_transaction(rpc, main_account, second_account):
     action = eosio_token.transfer(
         from_addr=main_account.name,
         to_addr=second_account.name,

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -127,18 +127,18 @@ def test_varuint_serializer():
 
 
 def test_eos_authorization_serializer():
-    value = types.EosAuthorization(actor='eosio', permission='active')
+    value = types.EosPermissionLevel(actor='eosio', permission='active')
     encoded = serializer.serialize(value)
     assert encoded == b'\x00\x00\x00\x00\x00\xea0U\x00\x00\x00\x00\xa8\xed22'
-    length, decoded = serializer.deserialize(encoded, types.EosAuthorization)
+    length, decoded = serializer.deserialize(encoded, types.EosPermissionLevel)
     assert decoded == value
     assert len(encoded) == length
 
 
 def test_eos_action_serializer():
     authorizations = [
-        types.EosAuthorization(actor='eosio', permission='active'),
-        types.EosAuthorization(actor='cryptobakery', permission='active')
+        types.EosPermissionLevel(actor='eosio', permission='active'),
+        types.EosPermissionLevel(actor='cryptobakery', permission='active')
     ]
     action = types.EosAction(
         account='eosio',
@@ -190,7 +190,7 @@ def test_eos_transaction_deserialize():
                 account='jinlianyule1',
                 name='create',
                 authorization=[
-                    types.EosAuthorization(
+                    types.EosPermissionLevel(
                         actor='jinlianyule1',
                         permission='active'
                     )
@@ -224,8 +224,8 @@ def test_eos_transaction_deserialize():
 
 def test_eos_transaction_serializer():
     authorizations = [
-        types.EosAuthorization(actor='eosio', permission='active'),
-        types.EosAuthorization(actor='cryptobakery', permission='active')
+        types.EosPermissionLevel(actor='eosio', permission='active'),
+        types.EosPermissionLevel(actor='cryptobakery', permission='active')
     ]
     action = types.EosAction(
         account='eosio',

--- a/tests/test_tx_flow.py
+++ b/tests/test_tx_flow.py
@@ -1,7 +1,15 @@
+import os
+
+import pytest
+
 from aioeos.contracts import eosio_token
 from aioeos.types import EosTransaction
 
 
+@pytest.mark.skipif(
+    os.environ.get('DISABLE_RPC_TESTS'),
+    reason='RPC tests are disabled'
+)
 async def test_tx_flow(rpc, main_account, second_account):
     action = eosio_token.transfer(
         from_addr=main_account.name,

--- a/tests/test_tx_flow.py
+++ b/tests/test_tx_flow.py
@@ -1,0 +1,22 @@
+from aioeos.contracts import eosio_token
+from aioeos.types import EosTransaction
+
+
+async def test_tx_flow(rpc, main_account, second_account):
+    action = eosio_token.transfer(
+        from_addr=main_account.name,
+        to_addr=second_account.name,
+        quantity='1.0000 EOS',
+        authorization=[main_account.authorization('active')]
+    )
+
+    block = await rpc.get_head_block()
+
+    transaction = EosTransaction(
+        ref_block_num=block['block_num'] & 65535,
+        ref_block_prefix=block['ref_block_prefix'],
+        actions=[action]
+    )
+
+    # would throw an exception if something went wrong
+    await rpc.sign_and_push_transaction(transaction, keys=[main_account.key])


### PR DESCRIPTION
- Simplify API to make it easier to get started,
- Cache chain ID, as it's not supposed to change EVER (maybe we should allow passing it explicitly when it's known?),
- Test library against real RPC node,
- Allow `BaseAbiObject`-derived dataclasses to be used as action payload, avoiding `abi_json_to_bin` call