### PR TITLE
Integrate abieos

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -33,7 +33,7 @@ jobs:
         poetry run flake8
     - name: Lint with mypy
       run: |
-        poetry run mypy aioeos
+        poetry run mypy
     - name: Test with pytest
       env:
         # eosio node won't bootstrap on Github Actions

--- a/aioeos/contracts/eosio.py
+++ b/aioeos/contracts/eosio.py
@@ -1,7 +1,16 @@
 """Helpers for creating actions on eosio contract"""
+from dataclasses import dataclass
 from typing import Optional
 
-from aioeos.types import EosAction, EosAuthority
+from aioeos.types import BaseAbiObject, EosAction, EosAuthority, Name
+
+
+@dataclass
+class EosNewAccount(BaseAbiObject):
+    creator: Name
+    name: Name
+    owner: EosAuthority
+    active: EosAuthority
 
 
 def newaccount(
@@ -16,12 +25,12 @@ def newaccount(
         account='eosio',
         name='newaccount',
         authorization=authorization,
-        data={
-            'creator': creator,
-            'name': account_name,
-            'owner': owner,
-            'active': active if active else owner
-        }
+        data=EosNewAccount(
+            creator=creator,
+            name=account_name,
+            owner=owner,
+            active=active if active else owner
+        )
     )
 
 

--- a/aioeos/keys.py
+++ b/aioeos/keys.py
@@ -143,10 +143,13 @@ class EosKey:
             if p.to_string() == self._vk.to_string():
                 return i
 
+    def to_compressed(self):
+        """Returns compressed public key"""
+        return self._vk.to_string(encoding='compressed')
+
     def to_public(self):
-        """Returns compressed, base58 encoded public key prefixed with EOS"""
-        compressed = self._vk.to_string(encoding='compressed')
-        return f'EOS{self._check_encode(compressed)}'
+        """Returns base58 encoded compressed public key prefixed with EOS"""
+        return f'EOS{self._check_encode(self.to_compressed())}'
 
     def to_wif(self):
         """Converts private key to legacy WIF format"""
@@ -220,7 +223,7 @@ class EosKey:
         return True
 
     def to_key_weight(self, weight: int) -> EosKeyWeight:
-        return EosKeyWeight(key=self.to_public(), weight=weight)
+        return EosKeyWeight(key=self.to_compressed(), weight=weight)
 
     def __eq__(self, other) -> bool:
         assert isinstance(other, EosKey), 'Can compare only to EosKey instance'

--- a/aioeos/rpc.py
+++ b/aioeos/rpc.py
@@ -135,8 +135,9 @@ class EosJsonRpc:
 
     async def load_abi(self, account_name: str) -> bool:
         response = await self.get_abi(account_name)
-        abi = response.get('abi', {})
-        return serializer.load_abi_json(account_name, abi)
+        return serializer.AbiSerializer.set_abi_from_json(
+            account_name, response.get('abi', {})
+        )
 
     async def get_table_rows(
         self, code, scope, table, table_key='', lower_bound='', upper_bound='',

--- a/aioeos/types/__init__.py
+++ b/aioeos/types/__init__.py
@@ -1,6 +1,6 @@
 from .abi import (
     UInt8, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64, VarUInt, Float32,
-    Float64, TimePointSec, TimePoint, Name, AbiBytes, BaseAbiObject,
+    Float64, TimePointSec, TimePoint, Name, AbiBytes, PublicKey, BaseAbiObject,
     is_abi_object
 )  # noqa
 
@@ -18,7 +18,7 @@ __all__ = [
     # base ABI types
     'UInt8', 'UInt16', 'UInt32', 'UInt64', 'Int8', 'Int16', 'Int32', 'Int64',
     'VarUInt', 'Float32', 'Float64', 'TimePointSec', 'TimePoint', 'Name',
-    'AbiBytes', 'BaseAbiObject', 'is_abi_object',
+    'AbiBytes', 'PublicKey', 'BaseAbiObject', 'is_abi_object',
 
     # authority
     'EosPermissionLevel', 'EosKeyWeight', 'EosPermissionLevelWeight',

--- a/aioeos/types/abi.py
+++ b/aioeos/types/abi.py
@@ -7,7 +7,7 @@ from typing import Any, ClassVar, Dict, NewType, TYPE_CHECKING
 # EOS ABI types
 # TODO: implement bool, uint128, int128, float128, block_timestamp_type,
 # symbol, symbol_code, asset, checksum160, checksum256, checksum512,
-# public_key, private_key, signature, extended_asset
+# signature, extended_asset
 if TYPE_CHECKING:
     UInt8 = int
     UInt16 = int
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
     TimePoint = datetime
     Name = str
     AbiBytes = bytes
+    PublicKey = bytes
+    PrivateKey = bytes
 else:
     # Our runtime logic depends on these being new types, but this makes mypy
     # require explicit casting
@@ -41,6 +43,8 @@ else:
     TimePointSec = NewType('TimePointSec', datetime)
     TimePoint = NewType('TimePoint', datetime)
     AbiBytes = NewType('AbiBytes', bytes)
+    PublicKey = NewType('PublicKey', bytes)
+    PrivateKey = NewType('PrivateKey', bytes)
 
     # this type is weird because it's like int, but it has no fixed size
     VarUInt = NewType('VarUInt', int)

--- a/aioeos/types/authority.py
+++ b/aioeos/types/authority.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from typing import List
 
-from .abi import AbiBytes, BaseAbiObject, UInt16, UInt32, Name
+from .abi import BaseAbiObject, UInt16, UInt32, Name, PublicKey
 
 
 @dataclass
@@ -12,7 +12,7 @@ class EosPermissionLevel(BaseAbiObject):
 
 @dataclass
 class EosKeyWeight(BaseAbiObject):
-    key: AbiBytes
+    key: PublicKey
     weight: UInt16
 
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,0 @@
-[mypy]
-
-[mypy-ecdsa]
-ignore_missing_imports = True

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,5 +1,13 @@
 [[package]]
 category = "main"
+description = "Python bindings for abieos library."
+name = "abieos-python"
+optional = false
+python-versions = "*"
+version = "1.0.0"
+
+[[package]]
+category = "main"
 description = "Async http client/server framework (asyncio)"
 name = "aiohttp"
 optional = false
@@ -116,7 +124,7 @@ description = "Code coverage measurement for Python"
 name = "coverage"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "5.0.4"
+version = "5.1"
 
 [package.extras]
 toml = ["toml"]
@@ -204,7 +212,7 @@ description = "A very fast and expressive template engine."
 name = "jinja2"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.11.1"
+version = "2.11.2"
 
 [package.dependencies]
 MarkupSafe = ">=0.23"
@@ -395,7 +403,7 @@ description = "Thin-wrapper around the mock package for easier use with pytest"
 name = "pytest-mock"
 optional = false
 python-versions = ">=3.5"
-version = "3.0.0"
+version = "3.1.0"
 
 [package.dependencies]
 pytest = ">=2.7"
@@ -595,11 +603,11 @@ description = "HTTP library with thread-safe connection pooling, file post, and 
 name = "urllib3"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "1.25.8"
+version = "1.25.9"
 
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
-secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=0.14)", "ipaddress"]
 socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 
 [[package]]
@@ -636,10 +644,19 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "ad4bc1c5e28daa0ab28cc28d63691e79f850c04b6aa5fa5ff37bf02971bea25e"
+content-hash = "cc28656174a258fce278271c68c97614b23fde430b88137a12a0b42a7c6caa88"
 python-versions = "^3.7"
 
 [metadata.files]
+abieos-python = [
+    {file = "abieos-python-1.0.0.macosx-10.13-x86_64.tar.gz", hash = "sha256:1217761e931a6c4642b69488db3f0ba34e0d93a48bb4715d8c2a158c083ede80"},
+    {file = "abieos_python-1.0.0-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:40da91a728d83b0ddd6c540741c75b63c7cfa2489fa78a673f652685eee88da8"},
+    {file = "abieos_python-1.0.0-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:47448f66452f0ebee667ca873b0ad743cd42f858bd0358ab12070d3341b72b11"},
+    {file = "abieos_python-1.0.0-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:3a34b5e46495867b999100f93de7aac5d883624441e57a43bf1f3c07fdfe9d3c"},
+    {file = "abieos_python-1.0.0-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6ef0cf415ea56eecb23c3b4679011e03f6abb4356d02860c87fb6de85ce115b9"},
+    {file = "abieos_python-1.0.0-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:9eae593b6a01a031fce0f504dd4cf81a5d1cc745bfa5d7cf5415190a7f821d37"},
+    {file = "abieos_python-1.0.0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:bc7da3ec4be7b13f49d7d77be44ae26b4502df000cbdbbdb4ac89f930a4216b0"},
+]
 aiohttp = [
     {file = "aiohttp-3.6.2-cp35-cp35m-macosx_10_13_x86_64.whl", hash = "sha256:1e984191d1ec186881ffaed4581092ba04f7c61582a177b187d3a2f07ed9719e"},
     {file = "aiohttp-3.6.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:50aaad128e6ac62e7bf7bd1f0c0a24bc968a0c0590a726d5a955af193544bcec"},
@@ -695,37 +712,37 @@ colorama = [
     {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
 ]
 coverage = [
-    {file = "coverage-5.0.4-cp27-cp27m-macosx_10_12_x86_64.whl", hash = "sha256:8a620767b8209f3446197c0e29ba895d75a1e272a36af0786ec70fe7834e4307"},
-    {file = "coverage-5.0.4-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:73aa6e86034dad9f00f4bbf5a666a889d17d79db73bc5af04abd6c20a014d9c8"},
-    {file = "coverage-5.0.4-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:408ce64078398b2ee2ec08199ea3fcf382828d2f8a19c5a5ba2946fe5ddc6c31"},
-    {file = "coverage-5.0.4-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:cda33311cb9fb9323958a69499a667bd728a39a7aa4718d7622597a44c4f1441"},
-    {file = "coverage-5.0.4-cp27-cp27m-win32.whl", hash = "sha256:5f587dfd83cb669933186661a351ad6fc7166273bc3e3a1531ec5c783d997aac"},
-    {file = "coverage-5.0.4-cp27-cp27m-win_amd64.whl", hash = "sha256:9fad78c13e71546a76c2f8789623eec8e499f8d2d799f4b4547162ce0a4df435"},
-    {file = "coverage-5.0.4-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:2e08c32cbede4a29e2a701822291ae2bc9b5220a971bba9d1e7615312efd3037"},
-    {file = "coverage-5.0.4-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:922fb9ef2c67c3ab20e22948dcfd783397e4c043a5c5fa5ff5e9df5529074b0a"},
-    {file = "coverage-5.0.4-cp35-cp35m-macosx_10_12_x86_64.whl", hash = "sha256:c3fc325ce4cbf902d05a80daa47b645d07e796a80682c1c5800d6ac5045193e5"},
-    {file = "coverage-5.0.4-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:046a1a742e66d065d16fb564a26c2a15867f17695e7f3d358d7b1ad8a61bca30"},
-    {file = "coverage-5.0.4-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:6ad6ca45e9e92c05295f638e78cd42bfaaf8ee07878c9ed73e93190b26c125f7"},
-    {file = "coverage-5.0.4-cp35-cp35m-win32.whl", hash = "sha256:eda55e6e9ea258f5e4add23bcf33dc53b2c319e70806e180aecbff8d90ea24de"},
-    {file = "coverage-5.0.4-cp35-cp35m-win_amd64.whl", hash = "sha256:4a8a259bf990044351baf69d3b23e575699dd60b18460c71e81dc565f5819ac1"},
-    {file = "coverage-5.0.4-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:f372cdbb240e09ee855735b9d85e7f50730dcfb6296b74b95a3e5dea0615c4c1"},
-    {file = "coverage-5.0.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a37c6233b28e5bc340054cf6170e7090a4e85069513320275a4dc929144dccf0"},
-    {file = "coverage-5.0.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:443be7602c790960b9514567917af538cac7807a7c0c0727c4d2bbd4014920fd"},
-    {file = "coverage-5.0.4-cp36-cp36m-win32.whl", hash = "sha256:165a48268bfb5a77e2d9dbb80de7ea917332a79c7adb747bd005b3a07ff8caf0"},
-    {file = "coverage-5.0.4-cp36-cp36m-win_amd64.whl", hash = "sha256:0a907199566269e1cfa304325cc3b45c72ae341fbb3253ddde19fa820ded7a8b"},
-    {file = "coverage-5.0.4-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:513e6526e0082c59a984448f4104c9bf346c2da9961779ede1fc458e8e8a1f78"},
-    {file = "coverage-5.0.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:3844c3dab800ca8536f75ae89f3cf566848a3eb2af4d9f7b1103b4f4f7a5dad6"},
-    {file = "coverage-5.0.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:641e329e7f2c01531c45c687efcec8aeca2a78a4ff26d49184dce3d53fc35014"},
-    {file = "coverage-5.0.4-cp37-cp37m-win32.whl", hash = "sha256:db1d4e38c9b15be1521722e946ee24f6db95b189d1447fa9ff18dd16ba89f732"},
-    {file = "coverage-5.0.4-cp37-cp37m-win_amd64.whl", hash = "sha256:62061e87071497951155cbccee487980524d7abea647a1b2a6eb6b9647df9006"},
-    {file = "coverage-5.0.4-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:65a7e00c00472cd0f59ae09d2fb8a8aaae7f4a0cf54b2b74f3138d9f9ceb9cb2"},
-    {file = "coverage-5.0.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1f66cf263ec77af5b8fe14ef14c5e46e2eb4a795ac495ad7c03adc72ae43fafe"},
-    {file = "coverage-5.0.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:85596aa5d9aac1bf39fe39d9fa1051b0f00823982a1de5766e35d495b4a36ca9"},
-    {file = "coverage-5.0.4-cp38-cp38-win32.whl", hash = "sha256:86a0ea78fd851b313b2e712266f663e13b6bc78c2fb260b079e8b67d970474b1"},
-    {file = "coverage-5.0.4-cp38-cp38-win_amd64.whl", hash = "sha256:03f630aba2b9b0d69871c2e8d23a69b7fe94a1e2f5f10df5049c0df99db639a0"},
-    {file = "coverage-5.0.4-cp39-cp39-win32.whl", hash = "sha256:7c9762f80a25d8d0e4ab3cb1af5d9dffbddb3ee5d21c43e3474c84bf5ff941f7"},
-    {file = "coverage-5.0.4-cp39-cp39-win_amd64.whl", hash = "sha256:4482f69e0701139d0f2c44f3c395d1d1d37abd81bfafbf9b6efbe2542679d892"},
-    {file = "coverage-5.0.4.tar.gz", hash = "sha256:1b60a95fc995649464e0cd48cecc8288bac5f4198f21d04b8229dc4097d76823"},
+    {file = "coverage-5.1-cp27-cp27m-macosx_10_12_x86_64.whl", hash = "sha256:0cb4be7e784dcdc050fc58ef05b71aa8e89b7e6636b99967fadbdba694cf2b65"},
+    {file = "coverage-5.1-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:c317eaf5ff46a34305b202e73404f55f7389ef834b8dbf4da09b9b9b37f76dd2"},
+    {file = "coverage-5.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:b83835506dfc185a319031cf853fa4bb1b3974b1f913f5bb1a0f3d98bdcded04"},
+    {file = "coverage-5.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5f2294dbf7875b991c381e3d5af2bcc3494d836affa52b809c91697449d0eda6"},
+    {file = "coverage-5.1-cp27-cp27m-win32.whl", hash = "sha256:de807ae933cfb7f0c7d9d981a053772452217df2bf38e7e6267c9cbf9545a796"},
+    {file = "coverage-5.1-cp27-cp27m-win_amd64.whl", hash = "sha256:bf9cb9a9fd8891e7efd2d44deb24b86d647394b9705b744ff6f8261e6f29a730"},
+    {file = "coverage-5.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:acf3763ed01af8410fc36afea23707d4ea58ba7e86a8ee915dfb9ceff9ef69d0"},
+    {file = "coverage-5.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:dec5202bfe6f672d4511086e125db035a52b00f1648d6407cc8e526912c0353a"},
+    {file = "coverage-5.1-cp35-cp35m-macosx_10_12_x86_64.whl", hash = "sha256:7a5bdad4edec57b5fb8dae7d3ee58622d626fd3a0be0dfceda162a7035885ecf"},
+    {file = "coverage-5.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:1601e480b9b99697a570cea7ef749e88123c04b92d84cedaa01e117436b4a0a9"},
+    {file = "coverage-5.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:dbe8c6ae7534b5b024296464f387d57c13caa942f6d8e6e0346f27e509f0f768"},
+    {file = "coverage-5.1-cp35-cp35m-win32.whl", hash = "sha256:a027ef0492ede1e03a8054e3c37b8def89a1e3c471482e9f046906ba4f2aafd2"},
+    {file = "coverage-5.1-cp35-cp35m-win_amd64.whl", hash = "sha256:0e61d9803d5851849c24f78227939c701ced6704f337cad0a91e0972c51c1ee7"},
+    {file = "coverage-5.1-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:2d27a3f742c98e5c6b461ee6ef7287400a1956c11421eb574d843d9ec1f772f0"},
+    {file = "coverage-5.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:66460ab1599d3cf894bb6baee8c684788819b71a5dc1e8fa2ecc152e5d752019"},
+    {file = "coverage-5.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5c542d1e62eece33c306d66fe0a5c4f7f7b3c08fecc46ead86d7916684b36d6c"},
+    {file = "coverage-5.1-cp36-cp36m-win32.whl", hash = "sha256:2742c7515b9eb368718cd091bad1a1b44135cc72468c731302b3d641895b83d1"},
+    {file = "coverage-5.1-cp36-cp36m-win_amd64.whl", hash = "sha256:dead2ddede4c7ba6cb3a721870f5141c97dc7d85a079edb4bd8d88c3ad5b20c7"},
+    {file = "coverage-5.1-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:01333e1bd22c59713ba8a79f088b3955946e293114479bbfc2e37d522be03355"},
+    {file = "coverage-5.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:e1ea316102ea1e1770724db01998d1603ed921c54a86a2efcb03428d5417e489"},
+    {file = "coverage-5.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:adeb4c5b608574a3d647011af36f7586811a2c1197c861aedb548dd2453b41cd"},
+    {file = "coverage-5.1-cp37-cp37m-win32.whl", hash = "sha256:782caea581a6e9ff75eccda79287daefd1d2631cc09d642b6ee2d6da21fc0a4e"},
+    {file = "coverage-5.1-cp37-cp37m-win_amd64.whl", hash = "sha256:00f1d23f4336efc3b311ed0d807feb45098fc86dee1ca13b3d6768cdab187c8a"},
+    {file = "coverage-5.1-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:402e1744733df483b93abbf209283898e9f0d67470707e3c7516d84f48524f55"},
+    {file = "coverage-5.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:a3f3654d5734a3ece152636aad89f58afc9213c6520062db3978239db122f03c"},
+    {file = "coverage-5.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6402bd2fdedabbdb63a316308142597534ea8e1895f4e7d8bf7476c5e8751fef"},
+    {file = "coverage-5.1-cp38-cp38-win32.whl", hash = "sha256:8fa0cbc7ecad630e5b0f4f35b0f6ad419246b02bc750de7ac66db92667996d24"},
+    {file = "coverage-5.1-cp38-cp38-win_amd64.whl", hash = "sha256:79a3cfd6346ce6c13145731d39db47b7a7b859c0272f02cdb89a3bdcbae233a0"},
+    {file = "coverage-5.1-cp39-cp39-win32.whl", hash = "sha256:a82b92b04a23d3c8a581fc049228bafde988abacba397d57ce95fe95e0338ab4"},
+    {file = "coverage-5.1-cp39-cp39-win_amd64.whl", hash = "sha256:bb28a7245de68bf29f6fb199545d072d1036a1917dca17a1e75bbb919e14ee8e"},
+    {file = "coverage-5.1.tar.gz", hash = "sha256:f90bfc4ad18450c80b024036eaf91e4a246ae287701aaa88eaebebf150868052"},
 ]
 docutils = [
     {file = "docutils-0.16-py2.py3-none-any.whl", hash = "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af"},
@@ -756,8 +773,8 @@ importlib-metadata = [
     {file = "importlib_metadata-1.6.0.tar.gz", hash = "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"},
 ]
 jinja2 = [
-    {file = "Jinja2-2.11.1-py2.py3-none-any.whl", hash = "sha256:b0eaf100007721b5c16c1fc1eecb87409464edc10469ddc9a22a27a99123be49"},
-    {file = "Jinja2-2.11.1.tar.gz", hash = "sha256:93187ffbc7808079673ef52771baa950426fd664d3aad1d0fa3e95644360e250"},
+    {file = "Jinja2-2.11.2-py2.py3-none-any.whl", hash = "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"},
+    {file = "Jinja2-2.11.2.tar.gz", hash = "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0"},
 ]
 markupsafe = [
     {file = "MarkupSafe-1.1.1-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161"},
@@ -882,8 +899,8 @@ pytest-cov = [
     {file = "pytest_cov-2.8.1-py2.py3-none-any.whl", hash = "sha256:cdbdef4f870408ebdbfeb44e63e07eb18bb4619fae852f6e760645fa36172626"},
 ]
 pytest-mock = [
-    {file = "pytest-mock-3.0.0.tar.gz", hash = "sha256:a4494016753a30231f8519bfd160242a0f3c8fb82ca36e7b6f82a7fb602ac6b8"},
-    {file = "pytest_mock-3.0.0-py2.py3-none-any.whl", hash = "sha256:98e02534f170e4f37d7e1abdfc5973fd4207aa609582291717f643764e71c925"},
+    {file = "pytest-mock-3.1.0.tar.gz", hash = "sha256:ce610831cedeff5331f4e2fc453a5dd65384303f680ab34bee2c6533855b431c"},
+    {file = "pytest_mock-3.1.0-py2.py3-none-any.whl", hash = "sha256:997729451dfc36b851a9accf675488c7020beccda15e11c75632ee3d1b1ccd71"},
 ]
 pytz = [
     {file = "pytz-2019.3-py2.py3-none-any.whl", hash = "sha256:1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d"},
@@ -966,8 +983,8 @@ typing-extensions = [
     {file = "typing_extensions-3.7.4.2.tar.gz", hash = "sha256:79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae"},
 ]
 urllib3 = [
-    {file = "urllib3-1.25.8-py2.py3-none-any.whl", hash = "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc"},
-    {file = "urllib3-1.25.8.tar.gz", hash = "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"},
+    {file = "urllib3-1.25.9-py2.py3-none-any.whl", hash = "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"},
+    {file = "urllib3-1.25.9.tar.gz", hash = "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527"},
 ]
 wcwidth = [
     {file = "wcwidth-0.1.9-py2.py3-none-any.whl", hash = "sha256:cafe2186b3c009a04067022ce1dcd79cb38d8d65ee4f4791b8888d6599d1bbe1"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ python = "^3.7"
 aiohttp = "^3.3.1"
 base58 = "2.0.0"
 ecdsa = "^0.15"
+abieos-python = "1.0.0"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.7.9"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 aiohttp==3.3.1
 base58==2.0.0
 ecdsa==0.13.3
+abieos-python==1.0.0
 
 # docs requirements
 sphinx==2.4.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[mypy]
+files = aioeos
+
+[mypy-ecdsa]
+ignore_missing_imports = True
+
+[mypy-abieos]
+ignore_missing_imports = True

--- a/tests/contracts/__init__.py
+++ b/tests/contracts/__init__.py
@@ -1,0 +1,4 @@
+from . import fake  # noqa
+
+
+__all__ = ['fake']

--- a/tests/contracts/fake.py
+++ b/tests/contracts/fake.py
@@ -1,0 +1,46 @@
+"""
+Fake, typed out contract for testing purposes
+"""
+from dataclasses import dataclass
+
+from aioeos.types import BaseAbiObject, EosAction, UInt8
+
+
+@dataclass
+class Payload(BaseAbiObject):
+    a: UInt8
+
+
+account = 'eosio.fake'
+name = 'test'
+abi = {
+    'version': 'eosio::abi/1.0',
+    'structs': [
+        {
+            'name': name,
+            'base': '',
+            'fields': [
+                {
+                    'name': 'a',
+                    'type': 'int8'
+                }
+            ]
+        }
+    ],
+    'actions': [
+        {
+            'name': name,
+            'type': name,
+            'ricardian_contract': ''
+        }
+    ]
+}
+
+
+def test(a: int, authorization=[]) -> EosAction:
+    return EosAction(
+        account=account,
+        name=name,
+        authorization=authorization,
+        data=Payload(a=a)
+    )

--- a/tests/eosio_abi.json
+++ b/tests/eosio_abi.json
@@ -1,0 +1,2098 @@
+{
+  "version": "eosio::abi/1.1",
+  "types": [],
+  "structs": [
+    {
+      "name": "abi_hash",
+      "base": "",
+      "fields": [
+        {
+          "name": "owner",
+          "type": "name"
+        },
+        {
+          "name": "hash",
+          "type": "checksum256"
+        }
+      ]
+    },
+    {
+      "name": "activate",
+      "base": "",
+      "fields": [
+        {
+          "name": "feature_digest",
+          "type": "checksum256"
+        }
+      ]
+    },
+    {
+      "name": "authority",
+      "base": "",
+      "fields": [
+        {
+          "name": "threshold",
+          "type": "uint32"
+        },
+        {
+          "name": "keys",
+          "type": "key_weight[]"
+        },
+        {
+          "name": "accounts",
+          "type": "permission_level_weight[]"
+        },
+        {
+          "name": "waits",
+          "type": "wait_weight[]"
+        }
+      ]
+    },
+    {
+      "name": "bid_refund",
+      "base": "",
+      "fields": [
+        {
+          "name": "bidder",
+          "type": "name"
+        },
+        {
+          "name": "amount",
+          "type": "asset"
+        }
+      ]
+    },
+    {
+      "name": "bidname",
+      "base": "",
+      "fields": [
+        {
+          "name": "bidder",
+          "type": "name"
+        },
+        {
+          "name": "newname",
+          "type": "name"
+        },
+        {
+          "name": "bid",
+          "type": "asset"
+        }
+      ]
+    },
+    {
+      "name": "bidrefund",
+      "base": "",
+      "fields": [
+        {
+          "name": "bidder",
+          "type": "name"
+        },
+        {
+          "name": "newname",
+          "type": "name"
+        }
+      ]
+    },
+    {
+      "name": "block_header",
+      "base": "",
+      "fields": [
+        {
+          "name": "timestamp",
+          "type": "uint32"
+        },
+        {
+          "name": "producer",
+          "type": "name"
+        },
+        {
+          "name": "confirmed",
+          "type": "uint16"
+        },
+        {
+          "name": "previous",
+          "type": "checksum256"
+        },
+        {
+          "name": "transaction_mroot",
+          "type": "checksum256"
+        },
+        {
+          "name": "action_mroot",
+          "type": "checksum256"
+        },
+        {
+          "name": "schedule_version",
+          "type": "uint32"
+        },
+        {
+          "name": "new_producers",
+          "type": "producer_schedule?"
+        }
+      ]
+    },
+    {
+      "name": "blockchain_parameters",
+      "base": "",
+      "fields": [
+        {
+          "name": "max_block_net_usage",
+          "type": "uint64"
+        },
+        {
+          "name": "target_block_net_usage_pct",
+          "type": "uint32"
+        },
+        {
+          "name": "max_transaction_net_usage",
+          "type": "uint32"
+        },
+        {
+          "name": "base_per_transaction_net_usage",
+          "type": "uint32"
+        },
+        {
+          "name": "net_usage_leeway",
+          "type": "uint32"
+        },
+        {
+          "name": "context_free_discount_net_usage_num",
+          "type": "uint32"
+        },
+        {
+          "name": "context_free_discount_net_usage_den",
+          "type": "uint32"
+        },
+        {
+          "name": "max_block_cpu_usage",
+          "type": "uint32"
+        },
+        {
+          "name": "target_block_cpu_usage_pct",
+          "type": "uint32"
+        },
+        {
+          "name": "max_transaction_cpu_usage",
+          "type": "uint32"
+        },
+        {
+          "name": "min_transaction_cpu_usage",
+          "type": "uint32"
+        },
+        {
+          "name": "max_transaction_lifetime",
+          "type": "uint32"
+        },
+        {
+          "name": "deferred_trx_expiration_window",
+          "type": "uint32"
+        },
+        {
+          "name": "max_transaction_delay",
+          "type": "uint32"
+        },
+        {
+          "name": "max_inline_action_size",
+          "type": "uint32"
+        },
+        {
+          "name": "max_inline_action_depth",
+          "type": "uint16"
+        },
+        {
+          "name": "max_authority_depth",
+          "type": "uint16"
+        }
+      ]
+    },
+    {
+      "name": "buyram",
+      "base": "",
+      "fields": [
+        {
+          "name": "payer",
+          "type": "name"
+        },
+        {
+          "name": "receiver",
+          "type": "name"
+        },
+        {
+          "name": "quant",
+          "type": "asset"
+        }
+      ]
+    },
+    {
+      "name": "buyrambytes",
+      "base": "",
+      "fields": [
+        {
+          "name": "payer",
+          "type": "name"
+        },
+        {
+          "name": "receiver",
+          "type": "name"
+        },
+        {
+          "name": "bytes",
+          "type": "uint32"
+        }
+      ]
+    },
+    {
+      "name": "buyrex",
+      "base": "",
+      "fields": [
+        {
+          "name": "from",
+          "type": "name"
+        },
+        {
+          "name": "amount",
+          "type": "asset"
+        }
+      ]
+    },
+    {
+      "name": "canceldelay",
+      "base": "",
+      "fields": [
+        {
+          "name": "canceling_auth",
+          "type": "permission_level"
+        },
+        {
+          "name": "trx_id",
+          "type": "checksum256"
+        }
+      ]
+    },
+    {
+      "name": "claimrewards",
+      "base": "",
+      "fields": [
+        {
+          "name": "owner",
+          "type": "name"
+        }
+      ]
+    },
+    {
+      "name": "closerex",
+      "base": "",
+      "fields": [
+        {
+          "name": "owner",
+          "type": "name"
+        }
+      ]
+    },
+    {
+      "name": "cnclrexorder",
+      "base": "",
+      "fields": [
+        {
+          "name": "owner",
+          "type": "name"
+        }
+      ]
+    },
+    {
+      "name": "connector",
+      "base": "",
+      "fields": [
+        {
+          "name": "balance",
+          "type": "asset"
+        },
+        {
+          "name": "weight",
+          "type": "float64"
+        }
+      ]
+    },
+    {
+      "name": "consolidate",
+      "base": "",
+      "fields": [
+        {
+          "name": "owner",
+          "type": "name"
+        }
+      ]
+    },
+    {
+      "name": "defcpuloan",
+      "base": "",
+      "fields": [
+        {
+          "name": "from",
+          "type": "name"
+        },
+        {
+          "name": "loan_num",
+          "type": "uint64"
+        },
+        {
+          "name": "amount",
+          "type": "asset"
+        }
+      ]
+    },
+    {
+      "name": "defnetloan",
+      "base": "",
+      "fields": [
+        {
+          "name": "from",
+          "type": "name"
+        },
+        {
+          "name": "loan_num",
+          "type": "uint64"
+        },
+        {
+          "name": "amount",
+          "type": "asset"
+        }
+      ]
+    },
+    {
+      "name": "delegatebw",
+      "base": "",
+      "fields": [
+        {
+          "name": "from",
+          "type": "name"
+        },
+        {
+          "name": "receiver",
+          "type": "name"
+        },
+        {
+          "name": "stake_net_quantity",
+          "type": "asset"
+        },
+        {
+          "name": "stake_cpu_quantity",
+          "type": "asset"
+        },
+        {
+          "name": "transfer",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "delegated_bandwidth",
+      "base": "",
+      "fields": [
+        {
+          "name": "from",
+          "type": "name"
+        },
+        {
+          "name": "to",
+          "type": "name"
+        },
+        {
+          "name": "net_weight",
+          "type": "asset"
+        },
+        {
+          "name": "cpu_weight",
+          "type": "asset"
+        }
+      ]
+    },
+    {
+      "name": "deleteauth",
+      "base": "",
+      "fields": [
+        {
+          "name": "account",
+          "type": "name"
+        },
+        {
+          "name": "permission",
+          "type": "name"
+        }
+      ]
+    },
+    {
+      "name": "deposit",
+      "base": "",
+      "fields": [
+        {
+          "name": "owner",
+          "type": "name"
+        },
+        {
+          "name": "amount",
+          "type": "asset"
+        }
+      ]
+    },
+    {
+      "name": "eosio_global_state",
+      "base": "blockchain_parameters",
+      "fields": [
+        {
+          "name": "max_ram_size",
+          "type": "uint64"
+        },
+        {
+          "name": "total_ram_bytes_reserved",
+          "type": "uint64"
+        },
+        {
+          "name": "total_ram_stake",
+          "type": "int64"
+        },
+        {
+          "name": "last_producer_schedule_update",
+          "type": "block_timestamp_type"
+        },
+        {
+          "name": "last_pervote_bucket_fill",
+          "type": "time_point"
+        },
+        {
+          "name": "pervote_bucket",
+          "type": "int64"
+        },
+        {
+          "name": "perblock_bucket",
+          "type": "int64"
+        },
+        {
+          "name": "total_unpaid_blocks",
+          "type": "uint32"
+        },
+        {
+          "name": "total_activated_stake",
+          "type": "int64"
+        },
+        {
+          "name": "thresh_activated_stake_time",
+          "type": "time_point"
+        },
+        {
+          "name": "last_producer_schedule_size",
+          "type": "uint16"
+        },
+        {
+          "name": "total_producer_vote_weight",
+          "type": "float64"
+        },
+        {
+          "name": "last_name_close",
+          "type": "block_timestamp_type"
+        }
+      ]
+    },
+    {
+      "name": "eosio_global_state2",
+      "base": "",
+      "fields": [
+        {
+          "name": "new_ram_per_block",
+          "type": "uint16"
+        },
+        {
+          "name": "last_ram_increase",
+          "type": "block_timestamp_type"
+        },
+        {
+          "name": "last_block_num",
+          "type": "block_timestamp_type"
+        },
+        {
+          "name": "total_producer_votepay_share",
+          "type": "float64"
+        },
+        {
+          "name": "revision",
+          "type": "uint8"
+        }
+      ]
+    },
+    {
+      "name": "eosio_global_state3",
+      "base": "",
+      "fields": [
+        {
+          "name": "last_vpay_state_update",
+          "type": "time_point"
+        },
+        {
+          "name": "total_vpay_share_change_rate",
+          "type": "float64"
+        }
+      ]
+    },
+    {
+      "name": "eosio_global_state4",
+      "base": "",
+      "fields": [
+        {
+          "name": "continuous_rate",
+          "type": "float64"
+        },
+        {
+          "name": "inflation_pay_factor",
+          "type": "int64"
+        },
+        {
+          "name": "votepay_factor",
+          "type": "int64"
+        }
+      ]
+    },
+    {
+      "name": "exchange_state",
+      "base": "",
+      "fields": [
+        {
+          "name": "supply",
+          "type": "asset"
+        },
+        {
+          "name": "base",
+          "type": "connector"
+        },
+        {
+          "name": "quote",
+          "type": "connector"
+        }
+      ]
+    },
+    {
+      "name": "fundcpuloan",
+      "base": "",
+      "fields": [
+        {
+          "name": "from",
+          "type": "name"
+        },
+        {
+          "name": "loan_num",
+          "type": "uint64"
+        },
+        {
+          "name": "payment",
+          "type": "asset"
+        }
+      ]
+    },
+    {
+      "name": "fundnetloan",
+      "base": "",
+      "fields": [
+        {
+          "name": "from",
+          "type": "name"
+        },
+        {
+          "name": "loan_num",
+          "type": "uint64"
+        },
+        {
+          "name": "payment",
+          "type": "asset"
+        }
+      ]
+    },
+    {
+      "name": "init",
+      "base": "",
+      "fields": [
+        {
+          "name": "version",
+          "type": "varuint32"
+        },
+        {
+          "name": "core",
+          "type": "symbol"
+        }
+      ]
+    },
+    {
+      "name": "key_weight",
+      "base": "",
+      "fields": [
+        {
+          "name": "key",
+          "type": "public_key"
+        },
+        {
+          "name": "weight",
+          "type": "uint16"
+        }
+      ]
+    },
+    {
+      "name": "linkauth",
+      "base": "",
+      "fields": [
+        {
+          "name": "account",
+          "type": "name"
+        },
+        {
+          "name": "code",
+          "type": "name"
+        },
+        {
+          "name": "type",
+          "type": "name"
+        },
+        {
+          "name": "requirement",
+          "type": "name"
+        }
+      ]
+    },
+    {
+      "name": "mvfrsavings",
+      "base": "",
+      "fields": [
+        {
+          "name": "owner",
+          "type": "name"
+        },
+        {
+          "name": "rex",
+          "type": "asset"
+        }
+      ]
+    },
+    {
+      "name": "mvtosavings",
+      "base": "",
+      "fields": [
+        {
+          "name": "owner",
+          "type": "name"
+        },
+        {
+          "name": "rex",
+          "type": "asset"
+        }
+      ]
+    },
+    {
+      "name": "name_bid",
+      "base": "",
+      "fields": [
+        {
+          "name": "newname",
+          "type": "name"
+        },
+        {
+          "name": "high_bidder",
+          "type": "name"
+        },
+        {
+          "name": "high_bid",
+          "type": "int64"
+        },
+        {
+          "name": "last_bid_time",
+          "type": "time_point"
+        }
+      ]
+    },
+    {
+      "name": "newaccount",
+      "base": "",
+      "fields": [
+        {
+          "name": "creator",
+          "type": "name"
+        },
+        {
+          "name": "name",
+          "type": "name"
+        },
+        {
+          "name": "owner",
+          "type": "authority"
+        },
+        {
+          "name": "active",
+          "type": "authority"
+        }
+      ]
+    },
+    {
+      "name": "onblock",
+      "base": "",
+      "fields": [
+        {
+          "name": "header",
+          "type": "block_header"
+        }
+      ]
+    },
+    {
+      "name": "onerror",
+      "base": "",
+      "fields": [
+        {
+          "name": "sender_id",
+          "type": "uint128"
+        },
+        {
+          "name": "sent_trx",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "pair_time_point_sec_int64",
+      "base": "",
+      "fields": [
+        {
+          "name": "key",
+          "type": "time_point_sec"
+        },
+        {
+          "name": "value",
+          "type": "int64"
+        }
+      ]
+    },
+    {
+      "name": "permission_level",
+      "base": "",
+      "fields": [
+        {
+          "name": "actor",
+          "type": "name"
+        },
+        {
+          "name": "permission",
+          "type": "name"
+        }
+      ]
+    },
+    {
+      "name": "permission_level_weight",
+      "base": "",
+      "fields": [
+        {
+          "name": "permission",
+          "type": "permission_level"
+        },
+        {
+          "name": "weight",
+          "type": "uint16"
+        }
+      ]
+    },
+    {
+      "name": "producer_info",
+      "base": "",
+      "fields": [
+        {
+          "name": "owner",
+          "type": "name"
+        },
+        {
+          "name": "total_votes",
+          "type": "float64"
+        },
+        {
+          "name": "producer_key",
+          "type": "public_key"
+        },
+        {
+          "name": "is_active",
+          "type": "bool"
+        },
+        {
+          "name": "url",
+          "type": "string"
+        },
+        {
+          "name": "unpaid_blocks",
+          "type": "uint32"
+        },
+        {
+          "name": "last_claim_time",
+          "type": "time_point"
+        },
+        {
+          "name": "location",
+          "type": "uint16"
+        }
+      ]
+    },
+    {
+      "name": "producer_info2",
+      "base": "",
+      "fields": [
+        {
+          "name": "owner",
+          "type": "name"
+        },
+        {
+          "name": "votepay_share",
+          "type": "float64"
+        },
+        {
+          "name": "last_votepay_share_update",
+          "type": "time_point"
+        }
+      ]
+    },
+    {
+      "name": "producer_key",
+      "base": "",
+      "fields": [
+        {
+          "name": "producer_name",
+          "type": "name"
+        },
+        {
+          "name": "block_signing_key",
+          "type": "public_key"
+        }
+      ]
+    },
+    {
+      "name": "producer_schedule",
+      "base": "",
+      "fields": [
+        {
+          "name": "version",
+          "type": "uint32"
+        },
+        {
+          "name": "producers",
+          "type": "producer_key[]"
+        }
+      ]
+    },
+    {
+      "name": "refund",
+      "base": "",
+      "fields": [
+        {
+          "name": "owner",
+          "type": "name"
+        }
+      ]
+    },
+    {
+      "name": "refund_request",
+      "base": "",
+      "fields": [
+        {
+          "name": "owner",
+          "type": "name"
+        },
+        {
+          "name": "request_time",
+          "type": "time_point_sec"
+        },
+        {
+          "name": "net_amount",
+          "type": "asset"
+        },
+        {
+          "name": "cpu_amount",
+          "type": "asset"
+        }
+      ]
+    },
+    {
+      "name": "regproducer",
+      "base": "",
+      "fields": [
+        {
+          "name": "producer",
+          "type": "name"
+        },
+        {
+          "name": "producer_key",
+          "type": "public_key"
+        },
+        {
+          "name": "url",
+          "type": "string"
+        },
+        {
+          "name": "location",
+          "type": "uint16"
+        }
+      ]
+    },
+    {
+      "name": "regproxy",
+      "base": "",
+      "fields": [
+        {
+          "name": "proxy",
+          "type": "name"
+        },
+        {
+          "name": "isproxy",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "rentcpu",
+      "base": "",
+      "fields": [
+        {
+          "name": "from",
+          "type": "name"
+        },
+        {
+          "name": "receiver",
+          "type": "name"
+        },
+        {
+          "name": "loan_payment",
+          "type": "asset"
+        },
+        {
+          "name": "loan_fund",
+          "type": "asset"
+        }
+      ]
+    },
+    {
+      "name": "rentnet",
+      "base": "",
+      "fields": [
+        {
+          "name": "from",
+          "type": "name"
+        },
+        {
+          "name": "receiver",
+          "type": "name"
+        },
+        {
+          "name": "loan_payment",
+          "type": "asset"
+        },
+        {
+          "name": "loan_fund",
+          "type": "asset"
+        }
+      ]
+    },
+    {
+      "name": "rex_balance",
+      "base": "",
+      "fields": [
+        {
+          "name": "version",
+          "type": "uint8"
+        },
+        {
+          "name": "owner",
+          "type": "name"
+        },
+        {
+          "name": "vote_stake",
+          "type": "asset"
+        },
+        {
+          "name": "rex_balance",
+          "type": "asset"
+        },
+        {
+          "name": "matured_rex",
+          "type": "int64"
+        },
+        {
+          "name": "rex_maturities",
+          "type": "pair_time_point_sec_int64[]"
+        }
+      ]
+    },
+    {
+      "name": "rex_fund",
+      "base": "",
+      "fields": [
+        {
+          "name": "version",
+          "type": "uint8"
+        },
+        {
+          "name": "owner",
+          "type": "name"
+        },
+        {
+          "name": "balance",
+          "type": "asset"
+        }
+      ]
+    },
+    {
+      "name": "rex_loan",
+      "base": "",
+      "fields": [
+        {
+          "name": "version",
+          "type": "uint8"
+        },
+        {
+          "name": "from",
+          "type": "name"
+        },
+        {
+          "name": "receiver",
+          "type": "name"
+        },
+        {
+          "name": "payment",
+          "type": "asset"
+        },
+        {
+          "name": "balance",
+          "type": "asset"
+        },
+        {
+          "name": "total_staked",
+          "type": "asset"
+        },
+        {
+          "name": "loan_num",
+          "type": "uint64"
+        },
+        {
+          "name": "expiration",
+          "type": "time_point"
+        }
+      ]
+    },
+    {
+      "name": "rex_order",
+      "base": "",
+      "fields": [
+        {
+          "name": "version",
+          "type": "uint8"
+        },
+        {
+          "name": "owner",
+          "type": "name"
+        },
+        {
+          "name": "rex_requested",
+          "type": "asset"
+        },
+        {
+          "name": "proceeds",
+          "type": "asset"
+        },
+        {
+          "name": "stake_change",
+          "type": "asset"
+        },
+        {
+          "name": "order_time",
+          "type": "time_point"
+        },
+        {
+          "name": "is_open",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "rex_pool",
+      "base": "",
+      "fields": [
+        {
+          "name": "version",
+          "type": "uint8"
+        },
+        {
+          "name": "total_lent",
+          "type": "asset"
+        },
+        {
+          "name": "total_unlent",
+          "type": "asset"
+        },
+        {
+          "name": "total_rent",
+          "type": "asset"
+        },
+        {
+          "name": "total_lendable",
+          "type": "asset"
+        },
+        {
+          "name": "total_rex",
+          "type": "asset"
+        },
+        {
+          "name": "namebid_proceeds",
+          "type": "asset"
+        },
+        {
+          "name": "loan_num",
+          "type": "uint64"
+        }
+      ]
+    },
+    {
+      "name": "rex_return_buckets",
+      "base": "",
+      "fields": [
+        {
+          "name": "version",
+          "type": "uint8"
+        },
+        {
+          "name": "return_buckets",
+          "type": "pair_time_point_sec_int64[]"
+        }
+      ]
+    },
+    {
+      "name": "rex_return_pool",
+      "base": "",
+      "fields": [
+        {
+          "name": "version",
+          "type": "uint8"
+        },
+        {
+          "name": "last_dist_time",
+          "type": "time_point_sec"
+        },
+        {
+          "name": "pending_bucket_time",
+          "type": "time_point_sec"
+        },
+        {
+          "name": "oldest_bucket_time",
+          "type": "time_point_sec"
+        },
+        {
+          "name": "pending_bucket_proceeds",
+          "type": "int64"
+        },
+        {
+          "name": "current_rate_of_increase",
+          "type": "int64"
+        },
+        {
+          "name": "proceeds",
+          "type": "int64"
+        }
+      ]
+    },
+    {
+      "name": "rexexec",
+      "base": "",
+      "fields": [
+        {
+          "name": "user",
+          "type": "name"
+        },
+        {
+          "name": "max",
+          "type": "uint16"
+        }
+      ]
+    },
+    {
+      "name": "rmvproducer",
+      "base": "",
+      "fields": [
+        {
+          "name": "producer",
+          "type": "name"
+        }
+      ]
+    },
+    {
+      "name": "sellram",
+      "base": "",
+      "fields": [
+        {
+          "name": "account",
+          "type": "name"
+        },
+        {
+          "name": "bytes",
+          "type": "int64"
+        }
+      ]
+    },
+    {
+      "name": "sellrex",
+      "base": "",
+      "fields": [
+        {
+          "name": "from",
+          "type": "name"
+        },
+        {
+          "name": "rex",
+          "type": "asset"
+        }
+      ]
+    },
+    {
+      "name": "setabi",
+      "base": "",
+      "fields": [
+        {
+          "name": "account",
+          "type": "name"
+        },
+        {
+          "name": "abi",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "setacctcpu",
+      "base": "",
+      "fields": [
+        {
+          "name": "account",
+          "type": "name"
+        },
+        {
+          "name": "cpu_weight",
+          "type": "int64?"
+        }
+      ]
+    },
+    {
+      "name": "setacctnet",
+      "base": "",
+      "fields": [
+        {
+          "name": "account",
+          "type": "name"
+        },
+        {
+          "name": "net_weight",
+          "type": "int64?"
+        }
+      ]
+    },
+    {
+      "name": "setacctram",
+      "base": "",
+      "fields": [
+        {
+          "name": "account",
+          "type": "name"
+        },
+        {
+          "name": "ram_bytes",
+          "type": "int64?"
+        }
+      ]
+    },
+    {
+      "name": "setalimits",
+      "base": "",
+      "fields": [
+        {
+          "name": "account",
+          "type": "name"
+        },
+        {
+          "name": "ram_bytes",
+          "type": "int64"
+        },
+        {
+          "name": "net_weight",
+          "type": "int64"
+        },
+        {
+          "name": "cpu_weight",
+          "type": "int64"
+        }
+      ]
+    },
+    {
+      "name": "setcode",
+      "base": "",
+      "fields": [
+        {
+          "name": "account",
+          "type": "name"
+        },
+        {
+          "name": "vmtype",
+          "type": "uint8"
+        },
+        {
+          "name": "vmversion",
+          "type": "uint8"
+        },
+        {
+          "name": "code",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "setinflation",
+      "base": "",
+      "fields": [
+        {
+          "name": "annual_rate",
+          "type": "int64"
+        },
+        {
+          "name": "inflation_pay_factor",
+          "type": "int64"
+        },
+        {
+          "name": "votepay_factor",
+          "type": "int64"
+        }
+      ]
+    },
+    {
+      "name": "setparams",
+      "base": "",
+      "fields": [
+        {
+          "name": "params",
+          "type": "blockchain_parameters"
+        }
+      ]
+    },
+    {
+      "name": "setpriv",
+      "base": "",
+      "fields": [
+        {
+          "name": "account",
+          "type": "name"
+        },
+        {
+          "name": "is_priv",
+          "type": "uint8"
+        }
+      ]
+    },
+    {
+      "name": "setram",
+      "base": "",
+      "fields": [
+        {
+          "name": "max_ram_size",
+          "type": "uint64"
+        }
+      ]
+    },
+    {
+      "name": "setramrate",
+      "base": "",
+      "fields": [
+        {
+          "name": "bytes_per_block",
+          "type": "uint16"
+        }
+      ]
+    },
+    {
+      "name": "setrex",
+      "base": "",
+      "fields": [
+        {
+          "name": "balance",
+          "type": "asset"
+        }
+      ]
+    },
+    {
+      "name": "undelegatebw",
+      "base": "",
+      "fields": [
+        {
+          "name": "from",
+          "type": "name"
+        },
+        {
+          "name": "receiver",
+          "type": "name"
+        },
+        {
+          "name": "unstake_net_quantity",
+          "type": "asset"
+        },
+        {
+          "name": "unstake_cpu_quantity",
+          "type": "asset"
+        }
+      ]
+    },
+    {
+      "name": "unlinkauth",
+      "base": "",
+      "fields": [
+        {
+          "name": "account",
+          "type": "name"
+        },
+        {
+          "name": "code",
+          "type": "name"
+        },
+        {
+          "name": "type",
+          "type": "name"
+        }
+      ]
+    },
+    {
+      "name": "unregprod",
+      "base": "",
+      "fields": [
+        {
+          "name": "producer",
+          "type": "name"
+        }
+      ]
+    },
+    {
+      "name": "unstaketorex",
+      "base": "",
+      "fields": [
+        {
+          "name": "owner",
+          "type": "name"
+        },
+        {
+          "name": "receiver",
+          "type": "name"
+        },
+        {
+          "name": "from_net",
+          "type": "asset"
+        },
+        {
+          "name": "from_cpu",
+          "type": "asset"
+        }
+      ]
+    },
+    {
+      "name": "updateauth",
+      "base": "",
+      "fields": [
+        {
+          "name": "account",
+          "type": "name"
+        },
+        {
+          "name": "permission",
+          "type": "name"
+        },
+        {
+          "name": "parent",
+          "type": "name"
+        },
+        {
+          "name": "auth",
+          "type": "authority"
+        }
+      ]
+    },
+    {
+      "name": "updaterex",
+      "base": "",
+      "fields": [
+        {
+          "name": "owner",
+          "type": "name"
+        }
+      ]
+    },
+    {
+      "name": "updtrevision",
+      "base": "",
+      "fields": [
+        {
+          "name": "revision",
+          "type": "uint8"
+        }
+      ]
+    },
+    {
+      "name": "user_resources",
+      "base": "",
+      "fields": [
+        {
+          "name": "owner",
+          "type": "name"
+        },
+        {
+          "name": "net_weight",
+          "type": "asset"
+        },
+        {
+          "name": "cpu_weight",
+          "type": "asset"
+        },
+        {
+          "name": "ram_bytes",
+          "type": "int64"
+        }
+      ]
+    },
+    {
+      "name": "voteproducer",
+      "base": "",
+      "fields": [
+        {
+          "name": "voter",
+          "type": "name"
+        },
+        {
+          "name": "proxy",
+          "type": "name"
+        },
+        {
+          "name": "producers",
+          "type": "name[]"
+        }
+      ]
+    },
+    {
+      "name": "voter_info",
+      "base": "",
+      "fields": [
+        {
+          "name": "owner",
+          "type": "name"
+        },
+        {
+          "name": "proxy",
+          "type": "name"
+        },
+        {
+          "name": "producers",
+          "type": "name[]"
+        },
+        {
+          "name": "staked",
+          "type": "int64"
+        },
+        {
+          "name": "last_vote_weight",
+          "type": "float64"
+        },
+        {
+          "name": "proxied_vote_weight",
+          "type": "float64"
+        },
+        {
+          "name": "is_proxy",
+          "type": "bool"
+        },
+        {
+          "name": "flags1",
+          "type": "uint32"
+        },
+        {
+          "name": "reserved2",
+          "type": "uint32"
+        },
+        {
+          "name": "reserved3",
+          "type": "asset"
+        }
+      ]
+    },
+    {
+      "name": "wait_weight",
+      "base": "",
+      "fields": [
+        {
+          "name": "wait_sec",
+          "type": "uint32"
+        },
+        {
+          "name": "weight",
+          "type": "uint16"
+        }
+      ]
+    },
+    {
+      "name": "withdraw",
+      "base": "",
+      "fields": [
+        {
+          "name": "owner",
+          "type": "name"
+        },
+        {
+          "name": "amount",
+          "type": "asset"
+        }
+      ]
+    }
+  ],
+  "actions": [
+    {
+      "name": "activate",
+      "type": "activate",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Activate Protocol Feature\nsummary: 'Activate protocol feature {{nowrap feature_digest}}'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/admin.png#9bf1cec664863bd6aaac0f814b235f8799fb02c850e9aa5da34e8a004bd6518e\n---\n\n{{$action.account}} activates the protocol feature with a digest of {{feature_digest}}."
+    },
+    {
+      "name": "bidname",
+      "type": "bidname",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Bid On a Premium Account Name\nsummary: '{{nowrap bidder}} bids on the premium account name {{nowrap newname}}'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/account.png#3d55a2fc3a5c20b456f5657faf666bc25ffd06f4836c5e8256f741149b0b294f\n---\n\n{{bidder}} bids {{bid}} on an auction to own the premium account name {{newname}}.\n\n{{bidder}} transfers {{bid}} to the system to cover the cost of the bid, which will be returned to {{bidder}} only if {{bidder}} is later outbid in the auction for {{newname}} by another account.\n\nIf the auction for {{newname}} closes with {{bidder}} remaining as the highest bidder, {{bidder}} will be authorized to create the account with name {{newname}}.\n\n## Bid refund behavior\n\nIf {{bidder}}’s bid on {{newname}} is later outbid by another account, {{bidder}} will be able to claim back the transferred amount of {{bid}}. The system will attempt to automatically do this on behalf of {{bidder}}, but the automatic refund may occasionally fail which will then require {{bidder}} to manually claim the refund with the bidrefund action.\n\n## Auction close criteria\n\nThe system should automatically close the auction for {{newname}} if it satisfies the condition that over a period of two minutes the following two properties continuously hold:\n\n- no one has bid on {{newname}} within the last 24 hours;\n- and, the value of the latest bid on {{newname}} is greater than the value of the bids on each of the other open auctions.\n\nBe aware that the condition to close the auction described above are sufficient but not necessary. The auction for {{newname}} cannot close unless both of the properties are simultaneously satisfied, but it may be closed without requiring the properties to hold for a period of 2 minutes."
+    },
+    {
+      "name": "bidrefund",
+      "type": "bidrefund",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Claim Refund on Name Bid\nsummary: 'Claim refund on {{nowrap newname}} bid'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/account.png#3d55a2fc3a5c20b456f5657faf666bc25ffd06f4836c5e8256f741149b0b294f\n---\n\n{{bidder}} claims refund on {{newname}} bid after being outbid by someone else."
+    },
+    {
+      "name": "buyram",
+      "type": "buyram",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Buy RAM\nsummary: '{{nowrap payer}} buys RAM on behalf of {{nowrap receiver}} by paying {{nowrap quant}}'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/resource.png#3830f1ce8cb07f7757dbcf383b1ec1b11914ac34a1f9d8b065f07600fa9dac19\n---\n\n{{payer}} buys RAM on behalf of {{receiver}} by paying {{quant}}. This transaction will incur a 0.5% fee out of {{quant}} and the amount of RAM delivered will depend on market rates."
+    },
+    {
+      "name": "buyrambytes",
+      "type": "buyrambytes",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Buy RAM\nsummary: '{{nowrap payer}} buys {{nowrap bytes}} bytes of RAM on behalf of {{nowrap receiver}}'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/resource.png#3830f1ce8cb07f7757dbcf383b1ec1b11914ac34a1f9d8b065f07600fa9dac19\n---\n\n{{payer}} buys approximately {{bytes}} bytes of RAM on behalf of {{receiver}} by paying market rates for RAM. This transaction will incur a 0.5% fee and the cost will depend on market rates."
+    },
+    {
+      "name": "buyrex",
+      "type": "buyrex",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Buy REX Tokens\nsummary: '{{nowrap from}} buys REX tokens in exchange for {{nowrap amount}} and their vote stake increases by {{nowrap amount}}'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/rex.png#d229837fa62a464b9c71e06060aa86179adf0b3f4e3b8c4f9702f4f4b0c340a8\n---\n\n{{amount}} is taken out of {{from}}’s REX fund and used to purchase REX tokens at the current market exchange rate. In order for the action to succeed, {{from}} must have voted for a proxy or at least 21 block producers. {{amount}} is added to {{from}}’s vote stake.\n\nA sell order of the purchased amount can only be initiated after waiting for the maturity period of 4 to 5 days to pass. Even then, depending on the market conditions, the initiated sell order may not be executed immediately."
+    },
+    {
+      "name": "canceldelay",
+      "type": "canceldelay",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Cancel Delayed Transaction\nsummary: '{{nowrap canceling_auth.actor}} cancels a delayed transaction'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/account.png#3d55a2fc3a5c20b456f5657faf666bc25ffd06f4836c5e8256f741149b0b294f\n---\n\n{{canceling_auth.actor}} cancels the delayed transaction with id {{trx_id}}."
+    },
+    {
+      "name": "claimrewards",
+      "type": "claimrewards",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Claim Block Producer Rewards\nsummary: '{{nowrap owner}} claims block and vote rewards'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/admin.png#9bf1cec664863bd6aaac0f814b235f8799fb02c850e9aa5da34e8a004bd6518e\n---\n\n{{owner}} claims block and vote rewards from the system."
+    },
+    {
+      "name": "closerex",
+      "type": "closerex",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Cleanup Unused REX Data\nsummary: 'Delete REX related DB entries and free associated RAM'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/rex.png#d229837fa62a464b9c71e06060aa86179adf0b3f4e3b8c4f9702f4f4b0c340a8\n---\n\nDelete REX related DB entries and free associated RAM for {{owner}}.\n\nTo fully delete all REX related DB entries, {{owner}} must ensure that their REX balance and REX fund amounts are both zero and they have no outstanding loans."
+    },
+    {
+      "name": "cnclrexorder",
+      "type": "cnclrexorder",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Cancel Scheduled REX Sell Order\nsummary: '{{nowrap owner}} cancels a scheduled sell order if not yet filled'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/rex.png#d229837fa62a464b9c71e06060aa86179adf0b3f4e3b8c4f9702f4f4b0c340a8\n---\n\n{{owner}} cancels their open sell order."
+    },
+    {
+      "name": "consolidate",
+      "type": "consolidate",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Consolidate REX Maturity Buckets Into One\nsummary: 'Consolidate REX maturity buckets into one'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/rex.png#d229837fa62a464b9c71e06060aa86179adf0b3f4e3b8c4f9702f4f4b0c340a8\n---\n\nConsolidate REX maturity buckets into one bucket that {{owner}} will not be able to sell until 4 to 5 days later."
+    },
+    {
+      "name": "defcpuloan",
+      "type": "defcpuloan",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Withdraw from the Fund of a Specific CPU Loan\nsummary: '{{nowrap from}} transfers {{nowrap amount}} from the fund of CPU loan number {{nowrap loan_num}} back to REX fund'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/rex.png#d229837fa62a464b9c71e06060aa86179adf0b3f4e3b8c4f9702f4f4b0c340a8\n---\n\n{{from}} transfers {{amount}} from the fund of CPU loan number {{loan_num}} back to REX fund."
+    },
+    {
+      "name": "defnetloan",
+      "type": "defnetloan",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Withdraw from the Fund of a Specific NET Loan\nsummary: '{{nowrap from}} transfers {{nowrap amount}} from the fund of NET loan number {{nowrap loan_num}} back to REX fund'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/rex.png#d229837fa62a464b9c71e06060aa86179adf0b3f4e3b8c4f9702f4f4b0c340a8\n---\n\n{{from}} transfers {{amount}} from the fund of NET loan number {{loan_num}} back to REX fund."
+    },
+    {
+      "name": "delegatebw",
+      "type": "delegatebw",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Stake Tokens for NET and/or CPU\nsummary: 'Stake tokens for NET and/or CPU and optionally transfer ownership'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/resource.png#3830f1ce8cb07f7757dbcf383b1ec1b11914ac34a1f9d8b065f07600fa9dac19\n---\n\n{{#if transfer}} {{from}} stakes on behalf of {{receiver}} {{stake_net_quantity}} for NET bandwidth and {{stake_cpu_quantity}} for CPU bandwidth.\n\nStaked tokens will also be transferred to {{receiver}}. The sum of these two quantities will be deducted from {{from}}’s liquid balance and add to the vote weight of {{receiver}}.\n{{else}}\n{{from}} stakes to self and delegates to {{receiver}} {{stake_net_quantity}} for NET bandwidth and {{stake_cpu_quantity}} for CPU bandwidth.\n\nThe sum of these two quantities add to the vote weight of {{from}}.\n{{/if}}"
+    },
+    {
+      "name": "deleteauth",
+      "type": "deleteauth",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Delete Account Permission\nsummary: 'Delete the {{nowrap permission}} permission of {{nowrap account}}'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/account.png#3d55a2fc3a5c20b456f5657faf666bc25ffd06f4836c5e8256f741149b0b294f\n---\n\nDelete the {{permission}} permission of {{account}}."
+    },
+    {
+      "name": "deposit",
+      "type": "deposit",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Deposit Into REX Fund\nsummary: 'Add to {{nowrap owner}}’s REX fund by transferring {{nowrap amount}} from {{nowrap owner}}’s liquid balance'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/rex.png#d229837fa62a464b9c71e06060aa86179adf0b3f4e3b8c4f9702f4f4b0c340a8\n---\n\nTransfer {{amount}} from {{owner}}’s liquid balance to {{owner}}’s REX fund. All proceeds and expenses related to REX are added to or taken out of this fund."
+    },
+    {
+      "name": "fundcpuloan",
+      "type": "fundcpuloan",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Deposit into the Fund of a Specific CPU Loan\nsummary: '{{nowrap from}} funds a CPU loan'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/rex.png#d229837fa62a464b9c71e06060aa86179adf0b3f4e3b8c4f9702f4f4b0c340a8\n---\n\n{{from}} transfers {{payment}} from REX fund to the fund of CPU loan number {{loan_num}} in order to be used in loan renewal at expiry. {{from}} can withdraw the total balance of the loan fund at any time."
+    },
+    {
+      "name": "fundnetloan",
+      "type": "fundnetloan",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Deposit into the Fund of a Specific NET Loan\nsummary: '{{nowrap from}} funds a NET loan'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/rex.png#d229837fa62a464b9c71e06060aa86179adf0b3f4e3b8c4f9702f4f4b0c340a8\n---\n\n{{from}} transfers {{payment}} from REX fund to the fund of NET loan number {{loan_num}} in order to be used in loan renewal at expiry. {{from}} can withdraw the total balance of the loan fund at any time."
+    },
+    {
+      "name": "init",
+      "type": "init",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Initialize System Contract\nsummary: 'Initialize system contract'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/admin.png#9bf1cec664863bd6aaac0f814b235f8799fb02c850e9aa5da34e8a004bd6518e\n---\n\nInitialize system contract. The core token symbol will be set to {{core}}."
+    },
+    {
+      "name": "linkauth",
+      "type": "linkauth",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Link Action to Permission\nsummary: '{{nowrap account}} sets the minimum required permission for the {{#if type}}{{nowrap type}} action of the{{/if}} {{nowrap code}} contract to {{nowrap requirement}}'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/account.png#3d55a2fc3a5c20b456f5657faf666bc25ffd06f4836c5e8256f741149b0b294f\n---\n\n{{account}} sets the minimum required permission for the {{#if type}}{{type}} action of the{{/if}} {{code}} contract to {{requirement}}.\n\n{{#if type}}{{else}}Any links explicitly associated to specific actions of {{code}} will take precedence.{{/if}}"
+    },
+    {
+      "name": "mvfrsavings",
+      "type": "mvfrsavings",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Unlock REX Tokens\nsummary: '{{nowrap owner}} unlocks REX Tokens'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/rex.png#d229837fa62a464b9c71e06060aa86179adf0b3f4e3b8c4f9702f4f4b0c340a8\n---\n\n{{owner}} unlocks {{rex}} by moving it out of the REX savings bucket. The unlocked REX tokens cannot be sold until 4 to 5 days later."
+    },
+    {
+      "name": "mvtosavings",
+      "type": "mvtosavings",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Lock REX Tokens\nsummary: '{{nowrap owner}} locks REX Tokens'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/rex.png#d229837fa62a464b9c71e06060aa86179adf0b3f4e3b8c4f9702f4f4b0c340a8\n---\n\n{{owner}} locks {{rex}} by moving it into the REX savings bucket. The locked REX tokens cannot be sold directly and will have to be unlocked explicitly before selling."
+    },
+    {
+      "name": "newaccount",
+      "type": "newaccount",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Create New Account\nsummary: '{{nowrap creator}} creates a new account with the name {{nowrap name}}'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/account.png#3d55a2fc3a5c20b456f5657faf666bc25ffd06f4836c5e8256f741149b0b294f\n---\n\n{{creator}} creates a new account with the name {{name}} and the following permissions:\n\nowner permission with authority:\n{{to_json owner}}\n\nactive permission with authority:\n{{to_json active}}"
+    },
+    {
+      "name": "onblock",
+      "type": "onblock",
+      "ricardian_contract": ""
+    },
+    {
+      "name": "onerror",
+      "type": "onerror",
+      "ricardian_contract": ""
+    },
+    {
+      "name": "refund",
+      "type": "refund",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Claim Unstaked Tokens\nsummary: 'Return previously unstaked tokens to {{nowrap owner}}'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/account.png#3d55a2fc3a5c20b456f5657faf666bc25ffd06f4836c5e8256f741149b0b294f\n---\n\nReturn previously unstaked tokens to {{owner}} after the unstaking period has elapsed."
+    },
+    {
+      "name": "regproducer",
+      "type": "regproducer",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Register as a Block Producer Candidate\nsummary: 'Register {{nowrap producer}} account as a block producer candidate'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/voting.png#db28cd3db6e62d4509af3644ce7d377329482a14bb4bfaca2aa5f1400d8e8a84\n---\n\nRegister {{producer}} account as a block producer candidate.\n\n{{$clauses.BlockProducerAgreement}}"
+    },
+    {
+      "name": "regproxy",
+      "type": "regproxy",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Register/unregister as a Proxy\nsummary: 'Register/unregister {{nowrap proxy}} as a proxy account'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/voting.png#db28cd3db6e62d4509af3644ce7d377329482a14bb4bfaca2aa5f1400d8e8a84\n---\n\n{{#if isproxy}}\n{{proxy}} registers as a proxy that can vote on behalf of accounts that appoint it as their proxy.\n{{else}}\n{{proxy}} unregisters as a proxy that can vote on behalf of accounts that appoint it as their proxy.\n{{/if}}"
+    },
+    {
+      "name": "rentcpu",
+      "type": "rentcpu",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Rent CPU Bandwidth for 30 Days\nsummary: '{{nowrap from}} pays {{nowrap loan_payment}} to rent CPU bandwidth for {{nowrap receiver}}'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/rex.png#d229837fa62a464b9c71e06060aa86179adf0b3f4e3b8c4f9702f4f4b0c340a8\n---\n\n{{from}} pays {{loan_payment}} to rent CPU bandwidth on behalf of {{receiver}} for a period of 30 days.\n\n{{loan_payment}} is taken out of {{from}}’s REX fund. The market price determines the number of tokens to be staked to {{receiver}}’s CPU resources. In addition, {{from}} provides {{loan_fund}}, which is also taken out of {{from}}’s REX fund, to be used for automatic renewal of the loan.\n\nAt expiration, if the loan has less funds than {{loan_payment}}, it is closed and lent tokens that have been staked are taken out of {{receiver}}’s CPU bandwidth. Otherwise, it is renewed at the market price at the time of renewal, that is, the number of staked tokens is recalculated and {{receiver}}’s CPU bandwidth is updated accordingly. {{from}} can fund or defund a loan at any time before expiration. When the loan is closed, {{from}} is refunded any tokens remaining in the loan fund."
+    },
+    {
+      "name": "rentnet",
+      "type": "rentnet",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Rent NET Bandwidth for 30 Days\nsummary: '{{nowrap from}} pays {{nowrap loan_payment}} to rent NET bandwidth for {{nowrap receiver}}'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/rex.png#d229837fa62a464b9c71e06060aa86179adf0b3f4e3b8c4f9702f4f4b0c340a8\n---\n\n{{from}} pays {{loan_payment}} to rent NET bandwidth on behalf of {{receiver}} for a period of 30 days.\n\n{{loan_payment}} is taken out of {{from}}’s REX fund. The market price determines the number of tokens to be staked to {{receiver}}’s NET resources for 30 days. In addition, {{from}} provides {{loan_fund}}, which is also taken out of {{from}}’s REX fund, to be used for automatic renewal of the loan.\n\nAt expiration, if the loan has less funds than {{loan_payment}}, it is closed and lent tokens that have been staked are taken out of {{receiver}}’s NET bandwidth. Otherwise, it is renewed at the market price at the time of renewal, that is, the number of staked tokens is recalculated and {{receiver}}’s NET bandwidth is updated accordingly. {{from}} can fund or defund a loan at any time before expiration. When the loan is closed, {{from}} is refunded any tokens remaining in the loan fund."
+    },
+    {
+      "name": "rexexec",
+      "type": "rexexec",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Perform REX Maintenance\nsummary: 'Process sell orders and expired loans'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/rex.png#d229837fa62a464b9c71e06060aa86179adf0b3f4e3b8c4f9702f4f4b0c340a8\n---\n\nPerforms REX maintenance by processing a maximum of {{max}} REX sell orders and expired loans. Any account can execute this action."
+    },
+    {
+      "name": "rmvproducer",
+      "type": "rmvproducer",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Forcibly Unregister a Block Producer Candidate\nsummary: '{{nowrap producer}} is unregistered as a block producer candidate'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/admin.png#9bf1cec664863bd6aaac0f814b235f8799fb02c850e9aa5da34e8a004bd6518e\n---\n\n{{$action.account}} unregisters {{producer}} as a block producer candidate. {{producer}} account will retain its votes and those votes can change based on voter stake changes or votes removed from {{producer}}. However new voters will not be able to vote for {{producer}} while it remains unregistered."
+    },
+    {
+      "name": "sellram",
+      "type": "sellram",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Sell RAM From Account\nsummary: 'Sell unused RAM from {{nowrap account}}'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/resource.png#3830f1ce8cb07f7757dbcf383b1ec1b11914ac34a1f9d8b065f07600fa9dac19\n---\n\nSell {{bytes}} bytes of unused RAM from account {{account}} at market price. This transaction will incur a 0.5% fee on the proceeds which depend on market rates."
+    },
+    {
+      "name": "sellrex",
+      "type": "sellrex",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Sell REX Tokens in Exchange for EOS\nsummary: '{{nowrap from}} sells {{nowrap rex}} tokens'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/rex.png#d229837fa62a464b9c71e06060aa86179adf0b3f4e3b8c4f9702f4f4b0c340a8\n---\n\n{{from}} initiates a sell order to sell {{rex}} tokens at the market exchange rate during the time at which the order is ultimately executed. If {{from}} already has an open sell order in the sell queue, {{rex}} will be added to the amount of the sell order without change the position of the sell order within the queue. Once the sell order is executed, proceeds are added to {{from}}’s REX fund, the value of sold REX tokens is deducted from {{from}}’s vote stake, and votes are updated accordingly.\n\nDepending on the market conditions, it may not be possible to fill the entire sell order immediately. In such a case, the sell order is added to the back of a sell queue. A sell order at the front of the sell queue will automatically be executed when the market conditions allow for the entire order to be filled. Regardless of the market conditions, the system is designed to execute this sell order within 30 days. {{from}} can cancel the order at any time before it is filled using the cnclrexorder action."
+    },
+    {
+      "name": "setabi",
+      "type": "setabi",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Deploy Contract ABI\nsummary: 'Deploy contract ABI on account {{nowrap account}}'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/account.png#3d55a2fc3a5c20b456f5657faf666bc25ffd06f4836c5e8256f741149b0b294f\n---\n\nDeploy the ABI file associated with the contract on account {{account}}."
+    },
+    {
+      "name": "setacctcpu",
+      "type": "setacctcpu",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Explicitly Manage the CPU Quota of Account\nsummary: 'Explicitly manage the CPU bandwidth quota of account {{nowrap account}}'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/admin.png#9bf1cec664863bd6aaac0f814b235f8799fb02c850e9aa5da34e8a004bd6518e\n---\n\n{{#if_has_value cpu_weight}}\nExplicitly manage the CPU bandwidth quota of account {{account}} by pinning it to a weight of {{cpu_weight}}.\n\n{{account}} can stake and unstake, however, it will not change their CPU bandwidth quota as long as it remains pinned.\n{{else}}\nUnpin the CPU bandwidth quota of account {{account}}. The CPU bandwidth quota of {{account}} will be driven by the current tokens staked for CPU bandwidth by {{account}}.\n{{/if_has_value}}"
+    },
+    {
+      "name": "setacctnet",
+      "type": "setacctnet",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Explicitly Manage the NET Quota of Account\nsummary: 'Explicitly manage the NET bandwidth quota of account {{nowrap account}}'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/admin.png#9bf1cec664863bd6aaac0f814b235f8799fb02c850e9aa5da34e8a004bd6518e\n---\n\n{{#if_has_value net_weight}}\nExplicitly manage the network bandwidth quota of account {{account}} by pinning it to a weight of {{net_weight}}.\n\n{{account}} can stake and unstake, however, it will not change their NET bandwidth quota as long as it remains pinned.\n{{else}}\nUnpin the NET bandwidth quota of account {{account}}. The NET bandwidth quota of {{account}} will be driven by the current tokens staked for NET bandwidth by {{account}}.\n{{/if_has_value}}"
+    },
+    {
+      "name": "setacctram",
+      "type": "setacctram",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Explicitly Manage the RAM Quota of Account\nsummary: 'Explicitly manage the RAM quota of account {{nowrap account}}'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/admin.png#9bf1cec664863bd6aaac0f814b235f8799fb02c850e9aa5da34e8a004bd6518e\n---\n\n{{#if_has_value ram_bytes}}\nExplicitly manage the RAM quota of account {{account}} by pinning it to {{ram_bytes}} bytes.\n\n{{account}} can buy and sell RAM, however, it will not change their RAM quota as long as it remains pinned.\n{{else}}\nUnpin the RAM quota of account {{account}}. The RAM quota of {{account}} will be driven by the current RAM holdings of {{account}}.\n{{/if_has_value}}"
+    },
+    {
+      "name": "setalimits",
+      "type": "setalimits",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Adjust Resource Limits of Account\nsummary: 'Adjust resource limits of account {{nowrap account}}'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/admin.png#9bf1cec664863bd6aaac0f814b235f8799fb02c850e9aa5da34e8a004bd6518e\n---\n\n{{$action.account}} updates {{account}}’s resource limits to have a RAM quota of {{ram_bytes}} bytes, a NET bandwidth quota of {{net_weight}} and a CPU bandwidth quota of {{cpu_weight}}."
+    },
+    {
+      "name": "setcode",
+      "type": "setcode",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Deploy Contract Code\nsummary: 'Deploy contract code on account {{nowrap account}}'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/account.png#3d55a2fc3a5c20b456f5657faf666bc25ffd06f4836c5e8256f741149b0b294f\n---\n\nDeploy compiled contract code to the account {{account}}."
+    },
+    {
+      "name": "setinflation",
+      "type": "setinflation",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Set Inflation Parameters\nsummary: 'Set inflation parameters'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/admin.png#9bf1cec664863bd6aaac0f814b235f8799fb02c850e9aa5da34e8a004bd6518e\n---\n\n{{$action.account}} sets the inflation parameters as follows:\n\n* Annual inflation rate (in units of a hundredth of a percent): {{annual_rate}}\n* Fraction of inflation used to reward block producers: 10000/{{inflation_pay_factor}}\n* Fraction of block producer rewards to be distributed proportional to blocks produced: 10000/{{votepay_factor}}"
+    },
+    {
+      "name": "setparams",
+      "type": "setparams",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Set System Parameters\nsummary: 'Set System Parameters'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/admin.png#9bf1cec664863bd6aaac0f814b235f8799fb02c850e9aa5da34e8a004bd6518e\n---\n\n{{$action.account}} sets system parameters to:\n{{to_json params}}"
+    },
+    {
+      "name": "setpriv",
+      "type": "setpriv",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Make an Account Privileged or Unprivileged\nsummary: '{{#if is_priv}}Make {{nowrap account}} privileged{{else}}Remove privileged status of {{nowrap account}}{{/if}}'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/admin.png#9bf1cec664863bd6aaac0f814b235f8799fb02c850e9aa5da34e8a004bd6518e\n---\n\n{{#if is_priv}}\n{{$action.account}} makes {{account}} privileged.\n{{else}}\n{{$action.account}} removes privileged status of {{account}}.\n{{/if}}"
+    },
+    {
+      "name": "setram",
+      "type": "setram",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Configure the Available RAM\nsummary: 'Configure the available RAM'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/admin.png#9bf1cec664863bd6aaac0f814b235f8799fb02c850e9aa5da34e8a004bd6518e\n---\n\n{{$action.account}} configures the available RAM to {{max_ram_size}} bytes."
+    },
+    {
+      "name": "setramrate",
+      "type": "setramrate",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Set the Rate of Increase of RAM\nsummary: 'Set the rate of increase of RAM per block'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/admin.png#9bf1cec664863bd6aaac0f814b235f8799fb02c850e9aa5da34e8a004bd6518e\n---\n\n{{$action.account}} sets the rate of increase of RAM to {{bytes_per_block}} bytes/block."
+    },
+    {
+      "name": "setrex",
+      "type": "setrex",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Adjust REX Pool Virtual Balance\nsummary: 'Adjust REX Pool Virtual Balance'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/admin.png#9bf1cec664863bd6aaac0f814b235f8799fb02c850e9aa5da34e8a004bd6518e\n---\n\n{{$action.account}} adjusts REX loan rate by setting REX pool virtual balance to {{balance}}. No token transfer or issue is executed in this action."
+    },
+    {
+      "name": "undelegatebw",
+      "type": "undelegatebw",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Unstake Tokens for NET and/or CPU\nsummary: 'Unstake tokens for NET and/or CPU from {{nowrap receiver}}'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/resource.png#3830f1ce8cb07f7757dbcf383b1ec1b11914ac34a1f9d8b065f07600fa9dac19\n---\n\n{{from}} unstakes from {{receiver}} {{unstake_net_quantity}} for NET bandwidth and {{unstake_cpu_quantity}} for CPU bandwidth.\n\nThe sum of these two quantities will be removed from the vote weight of {{receiver}} and will be made available to {{from}} after an uninterrupted 3 day period without further unstaking by {{from}}. After the uninterrupted 3 day period passes, the system will attempt to automatically return the funds to {{from}}’s regular token balance. However, this automatic refund may occasionally fail which will then require {{from}} to manually claim the funds with the refund action."
+    },
+    {
+      "name": "unlinkauth",
+      "type": "unlinkauth",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Unlink Action from Permission\nsummary: '{{nowrap account}} unsets the minimum required permission for the {{#if type}}{{nowrap type}} action of the{{/if}} {{nowrap code}} contract'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/account.png#3d55a2fc3a5c20b456f5657faf666bc25ffd06f4836c5e8256f741149b0b294f\n---\n\n{{account}} removes the association between the {{#if type}}{{type}} action of the{{/if}} {{code}} contract and its minimum required permission.\n\n{{#if type}}{{else}}This will not remove any links explicitly associated to specific actions of {{code}}.{{/if}}"
+    },
+    {
+      "name": "unregprod",
+      "type": "unregprod",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Unregister as a Block Producer Candidate\nsummary: '{{nowrap producer}} unregisters as a block producer candidate'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/voting.png#db28cd3db6e62d4509af3644ce7d377329482a14bb4bfaca2aa5f1400d8e8a84\n---\n\n{{producer}} unregisters as a block producer candidate. {{producer}} account will retain its votes and those votes can change based on voter stake changes or votes removed from {{producer}}. However new voters will not be able to vote for {{producer}} while it remains unregistered."
+    },
+    {
+      "name": "unstaketorex",
+      "type": "unstaketorex",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Buy REX Tokens Using Staked Tokens\nsummary: '{{nowrap owner}} buys REX tokens in exchange for tokens currently staked to NET and/or CPU'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/rex.png#d229837fa62a464b9c71e06060aa86179adf0b3f4e3b8c4f9702f4f4b0c340a8\n---\n\n{{from_net}} and {{from_cpu}} are withdrawn from {{receiver}}’s NET and CPU bandwidths respectively. These funds are used to purchase REX tokens at the current market exchange rate. In order for the action to succeed, {{owner}} must have voted for a proxy or at least 21 block producers.\n\nA sell order of the purchased amount can only be initiated after waiting for the maturity period of 4 to 5 days to pass. Even then, depending on the market conditions, the initiated sell order may not be executed immediately."
+    },
+    {
+      "name": "updateauth",
+      "type": "updateauth",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Modify Account Permission\nsummary: 'Add or update the {{nowrap permission}} permission of {{nowrap account}}'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/account.png#3d55a2fc3a5c20b456f5657faf666bc25ffd06f4836c5e8256f741149b0b294f\n---\n\nModify, and create if necessary, the {{permission}} permission of {{account}} to have a parent permission of {{parent}} and the following authority:\n{{to_json auth}}"
+    },
+    {
+      "name": "updaterex",
+      "type": "updaterex",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Update REX Owner Vote Weight\nsummary: 'Update vote weight to current value of held REX tokens'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/rex.png#d229837fa62a464b9c71e06060aa86179adf0b3f4e3b8c4f9702f4f4b0c340a8\n---\n\nUpdate vote weight of {{owner}} account to current value of held REX tokens."
+    },
+    {
+      "name": "updtrevision",
+      "type": "updtrevision",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Update System Contract Revision Number\nsummary: 'Update system contract revision number'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/admin.png#9bf1cec664863bd6aaac0f814b235f8799fb02c850e9aa5da34e8a004bd6518e\n---\n\n{{$action.account}} advances the system contract revision number to {{revision}}."
+    },
+    {
+      "name": "voteproducer",
+      "type": "voteproducer",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Vote for Block Producers\nsummary: '{{nowrap voter}} votes for {{#if proxy}}the proxy {{nowrap proxy}}{{else}}up to 30 block producer candidates{{/if}}'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/voting.png#db28cd3db6e62d4509af3644ce7d377329482a14bb4bfaca2aa5f1400d8e8a84\n---\n\n{{#if proxy}}\n{{voter}} votes for the proxy {{proxy}}.\nAt the time of voting the full weight of voter’s staked (CPU + NET) tokens will be cast towards each of the producers voted by {{proxy}}.\n{{else}}\n{{voter}} votes for the following block producer candidates:\n\n{{#each producers}}\n  + {{this}}\n{{/each}}\n\nAt the time of voting the full weight of voter’s staked (CPU + NET) tokens will be cast towards each of the above producers.\n{{/if}}"
+    },
+    {
+      "name": "withdraw",
+      "type": "withdraw",
+      "ricardian_contract": "---\nspec_version: \"0.2.0\"\ntitle: Withdraw from REX Fund\nsummary: 'Withdraw {{nowrap amount}} from {{nowrap owner}}’s REX fund by transferring to {{owner}}’s liquid balance'\nicon: http://127.0.0.1/ricardian_assets/eosio.contracts/icons/rex.png#d229837fa62a464b9c71e06060aa86179adf0b3f4e3b8c4f9702f4f4b0c340a8\n---\n\nWithdraws {{amount}} from {{owner}}’s REX fund and transfer them to {{owner}}’s liquid balance."
+    }
+  ],
+  "tables": [
+    {
+      "name": "abihash",
+      "index_type": "i64",
+      "key_names": [],
+      "key_types": [],
+      "type": "abi_hash"
+    },
+    {
+      "name": "bidrefunds",
+      "index_type": "i64",
+      "key_names": [],
+      "key_types": [],
+      "type": "bid_refund"
+    },
+    {
+      "name": "cpuloan",
+      "index_type": "i64",
+      "key_names": [],
+      "key_types": [],
+      "type": "rex_loan"
+    },
+    {
+      "name": "delband",
+      "index_type": "i64",
+      "key_names": [],
+      "key_types": [],
+      "type": "delegated_bandwidth"
+    },
+    {
+      "name": "global",
+      "index_type": "i64",
+      "key_names": [],
+      "key_types": [],
+      "type": "eosio_global_state"
+    },
+    {
+      "name": "global2",
+      "index_type": "i64",
+      "key_names": [],
+      "key_types": [],
+      "type": "eosio_global_state2"
+    },
+    {
+      "name": "global3",
+      "index_type": "i64",
+      "key_names": [],
+      "key_types": [],
+      "type": "eosio_global_state3"
+    },
+    {
+      "name": "global4",
+      "index_type": "i64",
+      "key_names": [],
+      "key_types": [],
+      "type": "eosio_global_state4"
+    },
+    {
+      "name": "namebids",
+      "index_type": "i64",
+      "key_names": [],
+      "key_types": [],
+      "type": "name_bid"
+    },
+    {
+      "name": "netloan",
+      "index_type": "i64",
+      "key_names": [],
+      "key_types": [],
+      "type": "rex_loan"
+    },
+    {
+      "name": "producers",
+      "index_type": "i64",
+      "key_names": [],
+      "key_types": [],
+      "type": "producer_info"
+    },
+    {
+      "name": "producers2",
+      "index_type": "i64",
+      "key_names": [],
+      "key_types": [],
+      "type": "producer_info2"
+    },
+    {
+      "name": "rammarket",
+      "index_type": "i64",
+      "key_names": [],
+      "key_types": [],
+      "type": "exchange_state"
+    },
+    {
+      "name": "refunds",
+      "index_type": "i64",
+      "key_names": [],
+      "key_types": [],
+      "type": "refund_request"
+    },
+    {
+      "name": "retbuckets",
+      "index_type": "i64",
+      "key_names": [],
+      "key_types": [],
+      "type": "rex_return_buckets"
+    },
+    {
+      "name": "rexbal",
+      "index_type": "i64",
+      "key_names": [],
+      "key_types": [],
+      "type": "rex_balance"
+    },
+    {
+      "name": "rexfund",
+      "index_type": "i64",
+      "key_names": [],
+      "key_types": [],
+      "type": "rex_fund"
+    },
+    {
+      "name": "rexpool",
+      "index_type": "i64",
+      "key_names": [],
+      "key_types": [],
+      "type": "rex_pool"
+    },
+    {
+      "name": "rexqueue",
+      "index_type": "i64",
+      "key_names": [],
+      "key_types": [],
+      "type": "rex_order"
+    },
+    {
+      "name": "rexretpool",
+      "index_type": "i64",
+      "key_names": [],
+      "key_types": [],
+      "type": "rex_return_pool"
+    },
+    {
+      "name": "userres",
+      "index_type": "i64",
+      "key_names": [],
+      "key_types": [],
+      "type": "user_resources"
+    },
+    {
+      "name": "voters",
+      "index_type": "i64",
+      "key_names": [],
+      "key_types": [],
+      "type": "voter_info"
+    }
+  ],
+  "ricardian_clauses": [
+    {
+      "id": "UserAgreement",
+      "body": "User agreement for the chain can go here."
+    },
+    {
+      "id": "BlockProducerAgreement",
+      "body": "I, {{producer}}, hereby nominate myself for consideration as an elected block producer.\n\nIf {{producer}} is selected to produce blocks by the system contract, I will sign blocks with {{producer_key}} and I hereby attest that I will keep this key secret and secure.\n\nIf {{producer}} is unable to perform obligations under this contract I will resign my position by resubmitting this contract with the null producer key.\n\nI acknowledge that a block is 'objectively valid' if it conforms to the deterministic blockchain rules in force at the time of its creation, and is 'objectively invalid' if it fails to conform to those rules.\n\n{{producer}} hereby agrees to only use {{producer_key}} to sign messages under the following scenarios:\n\n* proposing an objectively valid block at the time appointed by the block scheduling algorithm;\n* pre-confirming a block produced by another producer in the schedule when I find said block objectively valid;\n* and, confirming a block for which {{producer}} has received pre-confirmation messages from more than two-thirds of the active block producers.\n\nI hereby accept liability for any and all provable damages that result from my:\n\n* signing two different block proposals with the same timestamp with {{producer_key}};\n* signing two different block proposals with the same block number with {{producer_key}};\n* signing any block proposal which builds off of an objectively invalid block;\n* signing a pre-confirmation for an objectively invalid block;\n* or, signing a confirmation for a block for which I do not possess pre-confirmation messages from more than two-thirds of the active block producers.\n\nI hereby agree that double-signing for a timestamp or block number in concert with two or more other block producers shall automatically be deemed malicious and cause {{producer}} to be subject to:\n\n* a fine equal to the past year of compensation received,\n* immediate disqualification from being a producer,\n* and/or other damages.\n\nAn exception may be made if {{producer}} can demonstrate that the double-signing occurred due to a bug in the reference software; the burden of proof is on {{producer}}.\n\nI hereby agree not to interfere with the producer election process. I agree to process all producer election transactions that occur in blocks I create, to sign all objectively valid blocks I create that contain election transactions, and to sign all pre-confirmations and confirmations necessary to facilitate transfer of control to the next set of producers as determined by the system contract.\n\nI hereby acknowledge that more than two-thirds of the active block producers may vote to disqualify {{producer}} in the event {{producer}} is unable to produce blocks or is unable to be reached, according to criteria agreed to among block producers.\n\nIf {{producer}} qualifies for and chooses to collect compensation due to votes received, {{producer}} will provide a public endpoint allowing at least 100 peers to maintain synchronization with the blockchain and/or submit transactions to be included. {{producer}} shall maintain at least one validating node with full state and signature checking and shall report any objectively invalid blocks produced by the active block producers. Reporting shall be via a method to be agreed to among block producers, said method and reports to be made public.\n\nThe community agrees to allow {{producer}} to authenticate peers as necessary to prevent abuse and denial of service attacks; however, {{producer}} agrees not to discriminate against non-abusive peers.\n\nI agree to process transactions on a FIFO (first in, first out) best-effort basis and to honestly bill transactions for measured execution time.\n\nI {{producer}} agree not to manipulate the contents of blocks in order to derive profit from: the order in which transactions are included, or the hash of the block that is produced.\n\nI, {{producer}}, hereby agree to disclose and attest under penalty of perjury all ultimate beneficial owners of my business entity who own more than 10% and all direct shareholders.\n\nI, {{producer}}, hereby agree to cooperate with other block producers to carry out our respective and mutual obligations under this agreement, including but not limited to maintaining network stability and a valid blockchain.\n\nI, {{producer}}, agree to maintain a website hosted at {{url}} which contains up-to-date information on all disclosures required by this contract.\n\nI, {{producer}}, agree to set the location value of {{location}} such that {{producer}} is scheduled with minimal latency between my previous and next peer.\n\nI, {{producer}}, agree to maintain time synchronization within 10 ms of global atomic clock time, using a method agreed to among block producers.\n\nI, {{producer}}, agree not to produce blocks before my scheduled time unless I have received all blocks produced by the prior block producer.\n\nI, {{producer}}, agree not to publish blocks with timestamps more than 500ms in the future unless the prior block is more than 75% full by either NET or CPU bandwidth metrics.\n\nI, {{producer}}, agree not to set the RAM supply to more RAM than my nodes contain and to resign if I am unable to provide the RAM approved by more than two-thirds of active block producers, as shown in the system parameters."
+    }
+  ],
+  "error_messages": [],
+  "abi_extensions": [],
+  "variants": []
+}

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -1,6 +1,7 @@
 from aioeos import EosAction
 from aioeos.types import EosAuthority
 from aioeos.contracts import eosio, eosio_token
+from aioeos.contracts.eosio import EosNewAccount
 
 
 def test_eosio_token_transfer():
@@ -49,12 +50,12 @@ def test_eosio_newaccount(main_account):
             account='eosio',
             name='newaccount',
             authorization=[],
-            data={
-                'creator': main_account.name,
-                'name': 'eosio2',
-                'owner': authority,
-                'active': authority
-            }
+            data=EosNewAccount(
+                creator=main_account.name,
+                name='eosio2',
+                owner=authority,
+                active=authority
+            )
         )
     )
 

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -4,6 +4,8 @@ import pytest
 
 from aioeos import serializer, types, exceptions
 
+from tests.contracts import fake
+
 
 def test_unsupported_type_exception():
     with pytest.raises(exceptions.EosSerializerUnsupportedTypeException):
@@ -257,3 +259,15 @@ def test_eos_transaction_serializer():
     length, decoded = serializer.deserialize(encoded, types.EosTransaction)
     assert decoded == transaction
     assert len(encoded) == length
+
+
+def test_eos_abi_object_serializer():
+    data = {'a': 3}
+    payload = fake.Payload(**data)
+
+    assert serializer.load_abi_json(fake.account, fake.abi)
+    AbiSerializer = serializer.AbiSerializer
+
+    abi_type = AbiSerializer.get_type_for_action(fake.account, 'test')
+    value = AbiSerializer.json_to_bin(fake.account, abi_type, data)
+    assert serializer.serialize(payload) == value

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -83,6 +83,16 @@ def test_string_serializer():
     assert encoded != decoded
 
 
+def test_public_key_serializer(main_account):
+    s = serializer.PublicKeySerializer()
+    value = main_account.key.to_compressed()
+    encoded = s.serialize(value)
+    length, decoded = s.deserialize(encoded)
+    assert value == decoded
+    assert encoded != decoded
+    assert length == len(value)
+
+
 def test_abi_bytes_serializer():
     s = serializer.AbiBytesSerializer()
     value = b'\x00\x21\x37\x00'
@@ -262,11 +272,11 @@ def test_eos_transaction_serializer():
 
 
 def test_eos_abi_object_serializer():
+    AbiSerializer = serializer.AbiSerializer
     data = {'a': 3}
     payload = fake.Payload(**data)
 
-    assert serializer.load_abi_json(fake.account, fake.abi)
-    AbiSerializer = serializer.AbiSerializer
+    assert AbiSerializer.set_abi_from_json(fake.account, fake.abi)
 
     abi_type = AbiSerializer.get_type_for_action(fake.account, 'test')
     value = AbiSerializer.json_to_bin(fake.account, abi_type, data)


### PR DESCRIPTION
- Use abieos to serialize action payloads instead of abi_json_to_bin,
- Use abieos to deserialize action payloads,
- Add `public_key` ABI type, type out `newaccount` action