### PR TITLE
Bump base58 to 2.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ keywords = ["blockchain", "eos", "async", "eosio", "cryptocurrency"]
 [tool.poetry.dependencies]
 python = "^3.7"
 aiohttp = "^3.3.1"
-base58 = "2.0.0"
+base58 = "2.0.1"
 ecdsa = "^0.15"
 
 [tool.poetry.dev-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp==3.3.1
-base58==2.0.0
+base58==2.0.1
 ecdsa==0.13.3
 
 # docs requirements


### PR DESCRIPTION
No major changes were done between 2.0.0 and 2.0.1, and this will fix a lot of compatibility issues with other libraries that alredy require 2.0.1